### PR TITLE
feat(client): Use GET handlers for sinks, sources, and transforms

### DIFF
--- a/compose/base.yml
+++ b/compose/base.yml
@@ -69,6 +69,7 @@ services:
     environment:
       LOGLEVEL: debug
       DATABASE_URL: postgresql://postgres:password@timescaledb-service/postgres
+      MEZMO_API_EXTERNAL_HOSTNAME: api.use.dev.mezmo.it
       METRICS_DATABASE_URL: postgresql://postgres:password@timescaledb-metrics/postgres
       AWS_ENDPOINT: http://localstack:4566
       AWS_ACCESS_KEY: abcd

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -181,15 +181,15 @@ func (c *client) DeleteSource(pipelineId string, id string) error {
 // Source implements Client.
 // Gets a source from a pipeline.
 func (c *client) Source(pipelineId string, id string) (*Source, error) {
-	url := fmt.Sprintf("%s/v3/pipeline/%s", c.endpoint, pipelineId)
+	url := fmt.Sprintf("%s/v3/pipeline/%s/source/%s", c.endpoint, pipelineId, id)
 	req := c.newRequest(http.MethodGet, url, nil)
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[pipelineResponse]
+	var envelope apiResponseEnvelope[Source]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
-	pipeline := &envelope.Data
-	return pipeline.findSource(id)
+	source := &envelope.Data
+	return source, nil
 }
 
 // UpdateSource implements Client.
@@ -215,15 +215,15 @@ func (c *client) UpdateSource(pipelineId string, component *Source) (*Source, er
 // Sink implements Client.
 // Gets a sink.
 func (c *client) Sink(pipelineId string, id string) (*Sink, error) {
-	url := fmt.Sprintf("%s/v3/pipeline/%s", c.endpoint, pipelineId)
+	url := fmt.Sprintf("%s/v3/pipeline/%s/sink/%s", c.endpoint, pipelineId, id)
 	req := c.newRequest(http.MethodGet, url, nil)
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[pipelineResponse]
+	var envelope apiResponseEnvelope[Sink]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
-	pipeline := &envelope.Data
-	return pipeline.findSink(id)
+	sink := &envelope.Data
+	return sink, nil
 }
 
 // CreateSink implements Client.
@@ -270,15 +270,15 @@ func (c *client) UpdateSink(pipelineId string, component *Sink) (*Sink, error) {
 // Transform implements Client.
 // Gets a Transform.
 func (c *client) Transform(pipelineId string, id string) (*Transform, error) {
-	url := fmt.Sprintf("%s/v3/pipeline/%s", c.endpoint, pipelineId)
+	url := fmt.Sprintf("%s/v3/pipeline/%s/transform/%s", c.endpoint, pipelineId, id)
 	req := c.newRequest(http.MethodGet, url, nil)
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[pipelineResponse]
+	var envelope apiResponseEnvelope[Transform]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
-	pipeline := &envelope.Data
-	return pipeline.findTransform(id)
+	transform := &envelope.Data
+	return transform, nil
 }
 
 // CreateTransform implements Client.

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"fmt"
 	"time"
 )
 
@@ -44,34 +43,4 @@ type pipelineResponse struct {
 	Sources    []Source    `json:"sources"`
 	Transforms []Transform `json:"transforms"`
 	Sinks      []Sink      `json:"sinks"`
-}
-
-func (p *pipelineResponse) findSource(id string) (*Source, error) {
-	for _, s := range p.Sources {
-		if s.Id == id {
-			return &s, nil
-		}
-	}
-
-	return nil, fmt.Errorf("Source %s not found in pipeline %s", id, p.Id)
-}
-
-func (p *pipelineResponse) findSink(id string) (*Sink, error) {
-	for _, s := range p.Sinks {
-		if s.Id == id {
-			return &s, nil
-		}
-	}
-
-	return nil, fmt.Errorf("Sink %s not found in pipeline %s", id, p.Id)
-}
-
-func (p *pipelineResponse) findTransform(id string) (*Transform, error) {
-	for _, s := range p.Transforms {
-		if s.Id == id {
-			return &s, nil
-		}
-	}
-
-	return nil, fmt.Errorf("Transform %s not found in pipeline %s", id, p.Id)
 }


### PR DESCRIPTION
Previously, retrieving an individual sink, source, or transform required retrieving the whole pipeline, and then iterating over each of the components until the desired one is located. Instead, use the new GET handlers for these resources to retrieve them individually

Ref: LOG-17762

No additional tests were included in this PR because it looks like this code is covered by the existing tests. Happy to discuss this further and implement additional tests if others feel that they are in fact necessary.