### PR TITLE
refactor(provider): Use separate types for Source, Transform, Sink

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,19 +14,19 @@ type Client interface {
 	UpdatePipeline(pipeline *Pipeline) (*Pipeline, error)
 	DeletePipeline(id string) error
 
-	Source(pipelineId string, id string) (*Component, error)
-	CreateSource(pipelineId string, component *Component) (*Component, error)
-	UpdateSource(pipelineId string, component *Component) (*Component, error)
+	Source(pipelineId string, id string) (*Source, error)
+	CreateSource(pipelineId string, component *Source) (*Source, error)
+	UpdateSource(pipelineId string, component *Source) (*Source, error)
 	DeleteSource(pipelineId string, id string) error
 
-	Sink(pipelineId string, id string) (*Component, error)
-	CreateSink(pipelineId string, component *Component) (*Component, error)
-	UpdateSink(pipelineId string, component *Component) (*Component, error)
+	Sink(pipelineId string, id string) (*Sink, error)
+	CreateSink(pipelineId string, component *Sink) (*Sink, error)
+	UpdateSink(pipelineId string, component *Sink) (*Sink, error)
 	DeleteSink(pipelineId string, id string) error
 
-	Transform(pipelineId string, id string) (*Component, error)
-	CreateTransform(pipelineId string, component *Component) (*Component, error)
-	UpdateTransform(pipelineId string, component *Component) (*Component, error)
+	Transform(pipelineId string, id string) (*Transform, error)
+	CreateTransform(pipelineId string, component *Transform) (*Transform, error)
+	UpdateTransform(pipelineId string, component *Transform) (*Transform, error)
 	DeleteTransform(pipelineId string, id string) error
 }
 
@@ -155,7 +155,7 @@ func (c *client) newRequest(method string, url string, body io.Reader) *http.Req
 }
 
 // CreateSource implements Client.
-func (c *client) CreateSource(pipelineId string, component *Component) (*Component, error) {
+func (c *client) CreateSource(pipelineId string, component *Source) (*Source, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s/source", c.endpoint, pipelineId)
 	reqBody, err := json.Marshal(component)
 	if err != nil {
@@ -163,7 +163,7 @@ func (c *client) CreateSource(pipelineId string, component *Component) (*Compone
 	}
 	req := c.newRequest(http.MethodPost, url, bytes.NewReader(reqBody))
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[Component]
+	var envelope apiResponseEnvelope[Source]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (c *client) DeleteSource(pipelineId string, id string) error {
 
 // Source implements Client.
 // Gets a source from a pipeline.
-func (c *client) Source(pipelineId string, id string) (*Component, error) {
+func (c *client) Source(pipelineId string, id string) (*Source, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s", c.endpoint, pipelineId)
 	req := c.newRequest(http.MethodGet, url, nil)
 	resp, err := c.httpClient.Do(req)
@@ -193,7 +193,7 @@ func (c *client) Source(pipelineId string, id string) (*Component, error) {
 }
 
 // UpdateSource implements Client.
-func (c *client) UpdateSource(pipelineId string, component *Component) (*Component, error) {
+func (c *client) UpdateSource(pipelineId string, component *Source) (*Source, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s/source/%s", c.endpoint, pipelineId, component.Id)
 	reqBody, err := json.Marshal(component)
 	if err != nil {
@@ -201,7 +201,7 @@ func (c *client) UpdateSource(pipelineId string, component *Component) (*Compone
 	}
 	req := c.newRequest(http.MethodPut, url, bytes.NewReader(reqBody))
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[Component]
+	var envelope apiResponseEnvelope[Source]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
@@ -214,7 +214,7 @@ func (c *client) UpdateSource(pipelineId string, component *Component) (*Compone
 
 // Sink implements Client.
 // Gets a sink.
-func (c *client) Sink(pipelineId string, id string) (*Component, error) {
+func (c *client) Sink(pipelineId string, id string) (*Sink, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s", c.endpoint, pipelineId)
 	req := c.newRequest(http.MethodGet, url, nil)
 	resp, err := c.httpClient.Do(req)
@@ -227,7 +227,7 @@ func (c *client) Sink(pipelineId string, id string) (*Component, error) {
 }
 
 // CreateSink implements Client.
-func (c *client) CreateSink(pipelineId string, component *Component) (*Component, error) {
+func (c *client) CreateSink(pipelineId string, component *Sink) (*Sink, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s/sink", c.endpoint, pipelineId)
 	reqBody, err := json.Marshal(component)
 	if err != nil {
@@ -235,7 +235,7 @@ func (c *client) CreateSink(pipelineId string, component *Component) (*Component
 	}
 	req := c.newRequest(http.MethodPost, url, bytes.NewReader(reqBody))
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[Component]
+	var envelope apiResponseEnvelope[Sink]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
@@ -251,7 +251,7 @@ func (c *client) DeleteSink(pipelineId string, id string) error {
 }
 
 // UpdateSink implements Client.
-func (c *client) UpdateSink(pipelineId string, component *Component) (*Component, error) {
+func (c *client) UpdateSink(pipelineId string, component *Sink) (*Sink, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s/sink/%s", c.endpoint, pipelineId, component.Id)
 	reqBody, err := json.Marshal(component)
 	if err != nil {
@@ -259,7 +259,7 @@ func (c *client) UpdateSink(pipelineId string, component *Component) (*Component
 	}
 	req := c.newRequest(http.MethodPut, url, bytes.NewReader(reqBody))
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[Component]
+	var envelope apiResponseEnvelope[Sink]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (c *client) UpdateSink(pipelineId string, component *Component) (*Component
 
 // Transform implements Client.
 // Gets a Transform.
-func (c *client) Transform(pipelineId string, id string) (*Component, error) {
+func (c *client) Transform(pipelineId string, id string) (*Transform, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s", c.endpoint, pipelineId)
 	req := c.newRequest(http.MethodGet, url, nil)
 	resp, err := c.httpClient.Do(req)
@@ -282,7 +282,7 @@ func (c *client) Transform(pipelineId string, id string) (*Component, error) {
 }
 
 // CreateTransform implements Client.
-func (c *client) CreateTransform(pipelineId string, component *Component) (*Component, error) {
+func (c *client) CreateTransform(pipelineId string, component *Transform) (*Transform, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s/transform", c.endpoint, pipelineId)
 	reqBody, err := json.Marshal(component)
 	if err != nil {
@@ -290,7 +290,7 @@ func (c *client) CreateTransform(pipelineId string, component *Component) (*Comp
 	}
 	req := c.newRequest(http.MethodPost, url, bytes.NewReader(reqBody))
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[Component]
+	var envelope apiResponseEnvelope[Transform]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (c *client) DeleteTransform(pipelineId string, id string) error {
 }
 
 // UpdateTransform implements Client.
-func (c *client) UpdateTransform(pipelineId string, component *Component) (*Component, error) {
+func (c *client) UpdateTransform(pipelineId string, component *Transform) (*Transform, error) {
 	url := fmt.Sprintf("%s/v3/pipeline/%s/transform/%s", c.endpoint, pipelineId, component.Id)
 	reqBody, err := json.Marshal(component)
 	if err != nil {
@@ -314,7 +314,7 @@ func (c *client) UpdateTransform(pipelineId string, component *Component) (*Comp
 	}
 	req := c.newRequest(http.MethodPut, url, bytes.NewReader(reqBody))
 	resp, err := c.httpClient.Do(req)
-	var envelope apiResponseEnvelope[Component]
+	var envelope apiResponseEnvelope[Transform]
 	if err := readJson(&envelope, resp, err); err != nil {
 		return nil, err
 	}

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -13,26 +13,40 @@ type Pipeline struct {
 }
 
 // Represents a source, processor or destination.
-type Component struct {
-	Id             string         `json:"id,omitempty"`
-	Type           string         `json:"type"`
-	Inputs         []string       `json:"inputs,omitempty"`
-	Title          string         `json:"title,omitempty"`
-	Description    string         `json:"description,omitempty"`
-	UserConfig     map[string]any `json:"user_config"`
-	GenerationId   int64          `json:"generation_id"`
-	GatewayRouteId string         `json:"gateway_route_id,omitempty"`
+type BaseNode struct {
+	Id           string         `json:"id,omitempty"`
+	Type         string         `json:"type"`
+	Inputs       []string       `json:"inputs,omitempty"`
+	Title        string         `json:"title,omitempty"`
+	Description  string         `json:"description,omitempty"`
+	UserConfig   map[string]any `json:"user_config"`
+	GenerationId int64          `json:"generation_id"`
+}
+
+type Source struct {
+	BaseNode
+	GatewayRouteId string `json:"gateway_route_id,omitempty"`
+}
+type Transform struct {
+	BaseNode
+	OutputNames []struct {
+		Id    string `json:"id"`
+		Label string `json:"label"`
+	} `json:"output_names,omitempty"`
+}
+type Sink struct {
+	BaseNode
 }
 
 // Represents a full pipeline response from the service.
 type pipelineResponse struct {
 	Id         string      `json:"id"`
-	Sources    []Component `json:"sources"`
-	Transforms []Component `json:"transforms"`
-	Sinks      []Component `json:"sinks"`
+	Sources    []Source    `json:"sources"`
+	Transforms []Transform `json:"transforms"`
+	Sinks      []Sink      `json:"sinks"`
 }
 
-func (p *pipelineResponse) findSource(id string) (*Component, error) {
+func (p *pipelineResponse) findSource(id string) (*Source, error) {
 	for _, s := range p.Sources {
 		if s.Id == id {
 			return &s, nil
@@ -42,7 +56,7 @@ func (p *pipelineResponse) findSource(id string) (*Component, error) {
 	return nil, fmt.Errorf("Source %s not found in pipeline %s", id, p.Id)
 }
 
-func (p *pipelineResponse) findSink(id string) (*Component, error) {
+func (p *pipelineResponse) findSink(id string) (*Sink, error) {
 	for _, s := range p.Sinks {
 		if s.Id == id {
 			return &s, nil
@@ -52,7 +66,7 @@ func (p *pipelineResponse) findSink(id string) (*Component, error) {
 	return nil, fmt.Errorf("Sink %s not found in pipeline %s", id, p.Id)
 }
 
-func (p *pipelineResponse) findTransform(id string) (*Component, error) {
+func (p *pipelineResponse) findTransform(id string) (*Transform, error) {
 	for _, s := range p.Transforms {
 		if s.Id == id {
 			return &s, nil

--- a/internal/provider/models/sinks/blackhole.go
+++ b/internal/provider/models/sinks/blackhole.go
@@ -26,14 +26,16 @@ func BlackholeSinkResourceSchema() schema.Schema {
 	}
 }
 
-func BlackholeSinkFromModel(plan *BlackholeSinkModel, previousState *BlackholeSinkModel) (*Component, diag.Diagnostics) {
+func BlackholeSinkFromModel(plan *BlackholeSinkModel, previousState *BlackholeSinkModel) (*Sink, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
-	component := Component{
-		Type:        "blackhole",
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		UserConfig: map[string]any{
-			"ack_enabled": plan.AckEnabled.ValueBool(),
+	component := Sink{
+		BaseNode: BaseNode{
+			Type:        "blackhole",
+			Title:       plan.Title.ValueString(),
+			Description: plan.Description.ValueString(),
+			UserConfig: map[string]any{
+				"ack_enabled": plan.AckEnabled.ValueBool(),
+			},
 		},
 	}
 
@@ -54,7 +56,7 @@ func BlackholeSinkFromModel(plan *BlackholeSinkModel, previousState *BlackholeSi
 	return &component, dd
 }
 
-func BlackholeSinkToModel(plan *BlackholeSinkModel, component *Component) {
+func BlackholeSinkToModel(plan *BlackholeSinkModel, component *Sink) {
 	plan.Id = StringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = StringValue(component.Title)

--- a/internal/provider/models/sinks/http.go
+++ b/internal/provider/models/sinks/http.go
@@ -95,18 +95,20 @@ func HttpSinkResourceSchema() schema.Schema {
 	}
 }
 
-func HttpSinkFromModel(plan *HttpSinkModel, previousState *HttpSinkModel) (*Component, diag.Diagnostics) {
+func HttpSinkFromModel(plan *HttpSinkModel, previousState *HttpSinkModel) (*Sink, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
 
-	component := Component{
-		Type:        "http",
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		UserConfig: map[string]any{
-			"uri":         plan.Uri.ValueString(),
-			"encoding":    plan.Encoding.ValueString(),
-			"compression": plan.Compression.ValueString(),
-			"ack_enabled": plan.AckEnabled.ValueBool(),
+	component := Sink{
+		BaseNode: BaseNode{
+			Type:        "http",
+			Title:       plan.Title.ValueString(),
+			Description: plan.Description.ValueString(),
+			UserConfig: map[string]any{
+				"uri":         plan.Uri.ValueString(),
+				"encoding":    plan.Encoding.ValueString(),
+				"compression": plan.Compression.ValueString(),
+				"ack_enabled": plan.AckEnabled.ValueBool(),
+			},
 		},
 	}
 
@@ -140,7 +142,7 @@ func HttpSinkFromModel(plan *HttpSinkModel, previousState *HttpSinkModel) (*Comp
 	return &component, dd
 }
 
-func HttpSinkToModel(plan *HttpSinkModel, component *Component) {
+func HttpSinkToModel(plan *HttpSinkModel, component *Sink) {
 	plan.Id = StringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = StringValue(component.Title)

--- a/internal/provider/models/sources/demo.go
+++ b/internal/provider/models/sources/demo.go
@@ -35,13 +35,15 @@ func DemoSourceResourceSchema() schema.Schema {
 	}
 }
 
-func DemoSourceFromModel(plan *DemoSourceModel, previousState *DemoSourceModel) (*Component, diag.Diagnostics) {
+func DemoSourceFromModel(plan *DemoSourceModel, previousState *DemoSourceModel) (*Source, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
-	component := Component{
-		Type:        "demo-logs",
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		UserConfig:  map[string]any{"format": plan.Format.ValueString()},
+	component := Source{
+		BaseNode: BaseNode{
+			Type:        "demo-logs",
+			Title:       plan.Title.ValueString(),
+			Description: plan.Description.ValueString(),
+			UserConfig:  map[string]any{"format": plan.Format.ValueString()},
+		},
 	}
 
 	if previousState != nil {
@@ -52,7 +54,7 @@ func DemoSourceFromModel(plan *DemoSourceModel, previousState *DemoSourceModel) 
 	return &component, dd
 }
 
-func DemoSourceToModel(plan *DemoSourceModel, component *Component) {
+func DemoSourceToModel(plan *DemoSourceModel, component *Source) {
 	plan.Id = StringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = StringValue(component.Title)

--- a/internal/provider/models/sources/http.go
+++ b/internal/provider/models/sources/http.go
@@ -42,16 +42,18 @@ func HttpSourceResourceSchema() schema.Schema {
 	}
 }
 
-func HttpSourceFromModel(plan *HttpSourceModel, previousState *HttpSourceModel) (*Component, diag.Diagnostics) {
+func HttpSourceFromModel(plan *HttpSourceModel, previousState *HttpSourceModel) (*Source, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
 
-	component := Component{
-		Type:        "http",
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		UserConfig: map[string]any{
-			"decoding":         plan.Decoding.ValueString(),
-			"capture_metadata": plan.CaptureMetadata.ValueBool(),
+	component := Source{
+		BaseNode: BaseNode{
+			Type:        "http",
+			Title:       plan.Title.ValueString(),
+			Description: plan.Description.ValueString(),
+			UserConfig: map[string]any{
+				"decoding":         plan.Decoding.ValueString(),
+				"capture_metadata": plan.CaptureMetadata.ValueBool(),
+			},
 		},
 	}
 
@@ -79,7 +81,7 @@ func HttpSourceFromModel(plan *HttpSourceModel, previousState *HttpSourceModel) 
 	return &component, dd
 }
 
-func HttpSourceToModel(plan *HttpSourceModel, component *Component) {
+func HttpSourceToModel(plan *HttpSourceModel, component *Source) {
 	plan.Id = StringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = StringValue(component.Title)

--- a/internal/provider/models/sources/s3.go
+++ b/internal/provider/models/sources/s3.go
@@ -65,23 +65,25 @@ func S3SourceResourceSchema() schema.Schema {
 	}
 }
 
-func S3SourceFromModel(plan *S3SourceModel, previousState *S3SourceModel) (*Component, diag.Diagnostics) {
+func S3SourceFromModel(plan *S3SourceModel, previousState *S3SourceModel) (*Source, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
 	auth := plan.Auth.Attributes()
 	auth_access_key_id, _ := auth["access_key_id"].(basetypes.StringValue)
 	auth_secret_access_key, _ := auth["secret_access_key"].(basetypes.StringValue)
-	component := Component{
-		Type:        "s3",
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		UserConfig: map[string]any{
-			"region":        plan.Region.ValueString(),
-			"sqs_queue_url": plan.SqsQueueUrl.ValueString(),
-			"auth": map[string]string{
-				"access_key_id":     auth_access_key_id.ValueString(),
-				"secret_access_key": auth_secret_access_key.ValueString(),
+	component := Source{
+		BaseNode: BaseNode{
+			Type:        "s3",
+			Title:       plan.Title.ValueString(),
+			Description: plan.Description.ValueString(),
+			UserConfig: map[string]any{
+				"region":        plan.Region.ValueString(),
+				"sqs_queue_url": plan.SqsQueueUrl.ValueString(),
+				"auth": map[string]string{
+					"access_key_id":     auth_access_key_id.ValueString(),
+					"secret_access_key": auth_secret_access_key.ValueString(),
+				},
+				"compression": plan.Compression.ValueString(),
 			},
-			"compression": plan.Compression.ValueString(),
 		},
 	}
 
@@ -93,7 +95,7 @@ func S3SourceFromModel(plan *S3SourceModel, previousState *S3SourceModel) (*Comp
 	return &component, dd
 }
 
-func S3SourceToModel(plan *S3SourceModel, component *Component) {
+func S3SourceToModel(plan *S3SourceModel, component *Source) {
 	plan.Id = StringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = StringValue(component.Title)

--- a/internal/provider/models/transforms/stringify.go
+++ b/internal/provider/models/transforms/stringify.go
@@ -25,13 +25,15 @@ func StringifyTransformResourceSchema() schema.Schema {
 	}
 }
 
-func StringifyTransformFromModel(plan *StringifyTransformModel, previousState *StringifyTransformModel) (*Component, diag.Diagnostics) {
+func StringifyTransformFromModel(plan *StringifyTransformModel, previousState *StringifyTransformModel) (*Transform, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
-	component := Component{
-		Type:        "stringify",
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		UserConfig:  make(map[string]any),
+	component := Transform{
+		BaseNode: BaseNode{
+			Type:        "stringify",
+			Title:       plan.Title.ValueString(),
+			Description: plan.Description.ValueString(),
+			UserConfig:  make(map[string]any),
+		},
 	}
 
 	if !plan.Inputs.IsUnknown() {
@@ -51,7 +53,7 @@ func StringifyTransformFromModel(plan *StringifyTransformModel, previousState *S
 	return &component, dd
 }
 
-func StringifyTransformToModel(plan *StringifyTransformModel, component *Component) {
+func StringifyTransformToModel(plan *StringifyTransformModel, component *Transform) {
 	plan.Id = StringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = StringValue(component.Title)

--- a/internal/provider/sink_resource.go
+++ b/internal/provider/sink_resource.go
@@ -16,8 +16,8 @@ type SinkModel interface {
 type SinkResource[T SinkModel] struct {
 	client            Client
 	typeName          string
-	fromModelFunc     componentFromModelFunc[T]
-	toModelFunc       componentToModelFunc[T]
+	fromModelFunc     sinkFromModelFunc[T]
+	toModelFunc       sinkToModelFunc[T]
 	getIdFunc         idGetterFunc[T]
 	getPipelineIdFunc idGetterFunc[T]
 	getSchemaFunc     getSchemaFunc

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -16,8 +16,8 @@ type SourceModel interface {
 type SourceResource[T SourceModel] struct {
 	client            Client
 	typeName          string
-	fromModelFunc     componentFromModelFunc[T]
-	toModelFunc       componentToModelFunc[T]
+	fromModelFunc     sourceFromModelFunc[T]
+	toModelFunc       sourceToModelFunc[T]
 	getIdFunc         idGetterFunc[T]
 	getPipelineIdFunc idGetterFunc[T]
 	getSchemaFunc     getSchemaFunc

--- a/internal/provider/transform_resource.go
+++ b/internal/provider/transform_resource.go
@@ -16,8 +16,8 @@ type TransformModel interface {
 type TransformResource[T TransformModel] struct {
 	client            Client
 	typeName          string
-	fromModelFunc     componentFromModelFunc[T]
-	toModelFunc       componentToModelFunc[T]
+	fromModelFunc     transformFromModelFunc[T]
+	toModelFunc       transformToModelFunc[T]
 	getIdFunc         idGetterFunc[T]
 	getPipelineIdFunc idGetterFunc[T]
 	getSchemaFunc     getSchemaFunc

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -13,6 +13,13 @@ type ComponentModel interface {
 }
 
 type idGetterFunc[T ComponentModel] func(*T) basetypes.StringValue
-type componentToModelFunc[T ComponentModel] func(model *T, component *Component)
-type componentFromModelFunc[T ComponentModel] func(model *T, previousState *T) (*Component, diag.Diagnostics)
 type getSchemaFunc func() schema.Schema
+
+type sourceToModelFunc[T ComponentModel] func(model *T, component *Source)
+type sourceFromModelFunc[T ComponentModel] func(model *T, previousState *T) (*Source, diag.Diagnostics)
+
+type transformToModelFunc[T ComponentModel] func(model *T, component *Transform)
+type transformFromModelFunc[T ComponentModel] func(model *T, previousState *T) (*Transform, diag.Diagnostics)
+
+type sinkToModelFunc[T ComponentModel] func(model *T, component *Sink)
+type sinkFromModelFunc[T ComponentModel] func(model *T, previousState *T) (*Sink, diag.Diagnostics)


### PR DESCRIPTION
Using `Component` as a generic struct for our node types will not work moving forward. There are unique fields per-type such as `gateway_route_id`, and `output_names` for transforms. This commit uses composition to change `Component` into `BaseNode` properties to be extended to each new type Source, Sink and Transform.

Ref: LOG-17920