### PR TITLE
feat: Include auth scheme and clean up Provider's auth attributes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,12 +3,12 @@
 page_title: "mezmo Provider"
 subcategory: ""
 description: |-
-  
+  The Mezmo Terraform Provider allows organizations to manage Pipelines (sources, processors and destinations) programmatically via Terraform.
 ---
 
 # mezmo Provider
 
-
+The Mezmo Terraform Provider allows organizations to manage Pipelines (sources, processors and destinations) programmatically via Terraform.
 
 
 
@@ -21,6 +21,5 @@ description: |-
 
 ### Optional
 
-- `auth_additional` (String) Used for direct auth schemes in test scenarios
-- `auth_header` (String)
 - `endpoint` (String) Mezmo API endpoint containing the url scheme, host and port
+- `headers` (Map of String) Optional map of headers to send in each request

--- a/internal/provider/providertest/utils.go
+++ b/internal/provider/providertest/utils.go
@@ -45,12 +45,15 @@ func GetTestEndpoint() string {
 func GetProviderConfig() string {
 	return fmt.Sprintf(`
 		provider "mezmo" {
-			auth_key        = %q
-			endpoint        = %q
-			auth_header     = "x-auth-account-id" // Used for authenticating against the service directly
-			auth_additional = "info@mezmo.com"
+			endpoint = %q
+			auth_key = ""
+			headers  = {
+				// Used for authenticating against the service directly
+				"x-auth-account-id"  = %q
+				"x-auth-user-email" = "info@mezmo.com"
+			}
 		}
-		`, authAccountId, GetTestEndpoint())
+		`, GetTestEndpoint(), authAccountId)
 }
 
 func TestPreCheck(t *testing.T) {


### PR DESCRIPTION
Include the auth scheme prefix "Token" required by our auth plugin and expose a simple "headers" property in the Provider to support testing.

Ref: LOG-17135