### PR TITLE
fix(processors): `reduce` is missing properties in "to model"

### DIFF
--- a/internal/provider/models/processors/reduce.go
+++ b/internal/provider/models/processors/reduce.go
@@ -246,6 +246,45 @@ func ReduceProcessorToModel(plan *ReduceProcessorModel, component *Processor) {
 		}
 		plan.Inputs = NewListValueMust(StringType{}, inputs)
 	}
+
+	plan.DurationMs = NewInt64Value(int64(component.UserConfig["duration_ms"].(float64)))
+
+	if component.UserConfig["group_by"] != nil {
+		plan.GroupBy = SliceToStringListValue(component.UserConfig["group_by"].([]any))
+	}
+
+	if component.UserConfig["date_formats"] != nil {
+		dateFormats := make([]attr.Value, 0)
+		for _, v := range component.UserConfig["date_formats"].([]any) {
+			dateFormats = append(dateFormats, NewObjectValueMust(map[string]attr.Type{
+				"field":  StringType{},
+				"format": StringType{},
+			}, map[string]attr.Value{
+				"field":  NewStringValue(v.(map[string]any)["field"].(string)),
+				"format": NewStringValue(v.(map[string]any)["format"].(string)),
+			}))
+		}
+		plan.DateFormats = NewListValueMust(ObjectType{
+			AttrTypes: dateFormats[0].Type(context.Background()).(ObjectType).AttributeTypes(),
+		}, dateFormats)
+	}
+
+	if component.UserConfig["merge_strategies"] != nil {
+		mergeStrategies := make([]attr.Value, 0)
+		for _, v := range component.UserConfig["merge_strategies"].([]any) {
+			mergeStrategies = append(mergeStrategies, NewObjectValueMust(map[string]attr.Type{
+				"field":    StringType{},
+				"strategy": StringType{},
+			}, map[string]attr.Value{
+				"field":    NewStringValue(v.(map[string]any)["field"].(string)),
+				"strategy": NewStringValue(v.(map[string]any)["strategy"].(string)),
+			}))
+		}
+		plan.MergeStrategies = NewListValueMust(ObjectType{
+			AttrTypes: mergeStrategies[0].Type(context.Background()).(ObjectType).AttributeTypes(),
+		}, mergeStrategies)
+	}
+
 	if component.UserConfig["flush_condition"] != nil {
 		flushCondition := component.UserConfig["flush_condition"].(map[string]any)
 

--- a/internal/provider/models/processors/test/reduce_test.go
+++ b/internal/provider/models/processors/test/reduce_test.go
@@ -117,6 +117,7 @@ func TestReduceProcessor(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						inputs = [mezmo_http_source.my_source.id]
 
+						duration_ms = 15000
 						group_by    = [".field1.id"]
 						date_formats = [
 							{
@@ -138,7 +139,7 @@ func TestReduceProcessor(t *testing.T) {
 						"description":                 "processor desc",
 						"generation_id":               "1",
 						"inputs.#":                    "1",
-						"duration_ms":                 "30000",
+						"duration_ms":                 "15000",
 						"group_by.#":                  "1",
 						"group_by.0":                  ".field1.id",
 						"date_formats.#":              "1",


### PR DESCRIPTION
Because of the bug in LOG-18104, it went unnoticed that there were properties from the API response that were not added back into the plan.

Ref: LOG-18113