### PR TITLE
fix: Out-of-sync state is causing false positive test assertions

### DIFF
--- a/docs/resources/gcp_cloud_storage_destination.md
+++ b/docs/resources/gcp_cloud_storage_destination.md
@@ -25,11 +25,11 @@ Publish log events to GCP Cloud Storage
 
 - `ack_enabled` (Boolean) Acknowledge data from the source when it reaches the destination
 - `batch_timeout_secs` (Number) The maximum amount of time, in seconds, events will be buffered before being flushed to the destination
+- `bucket_prefix` (String) The prefix applied to the bucket name, giving the appearance of having directories.
 - `compression` (String) The compression strategy used on the encoded data prior to sending.
 - `description` (String) A user-defined value describing the destination
 - `encoding` (String) Dictates how the data will be serialized before storing.
 - `inputs` (List of String) The ids of the input components
-- `prefix` (String) The prefix applied to the bucket name, giving the appearance of having directories.
 - `title` (String) A user-defined title for the destination
 
 ### Read-Only

--- a/examples/destinations/gcp_cloud_storage.tf
+++ b/examples/destinations/gcp_cloud_storage.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    mezmo = {
+      source = "registry.terraform.io/mezmo/mezmo"
+    }
+  }
+  required_version = ">= 1.1.0"
+}
+
+provider "mezmo" {
+  auth_key = "my secret"
+}
+
+resource "mezmo_pipeline" "pipeline1" {
+  title = "My pipeline"
+}
+
+resource "mezmo_demo_source" "source1" {
+  pipeline_id = mezmo_pipeline.pipeline1.id
+  title       = "My source"
+  description = "This is some fake data for testing"
+  format      = "nginx"
+}
+
+resource "mezmo_gcp_cloud_storage_destination" "gcp" {
+  title         = "GCP"
+  description   = "This stores our data in GCP cloud storage"
+  inputs        = [mezmo_demo_source.source1.id]
+  pipeline_id   = mezmo_pipeline.pipeline1.id
+  encoding      = "json"
+  compression   = "gzip"
+  bucket        = "test_bucket"
+  bucket_prefix = "bucket_prefix"
+  auth = {
+    type  = "api_key"
+    value = "key"
+  }
+
+}

--- a/internal/provider/models/destinations/azure_blob_storage.go
+++ b/internal/provider/models/destinations/azure_blob_storage.go
@@ -18,13 +18,13 @@ type AzureBlobStorageDestinationModel struct {
 	Description         String `tfsdk:"description"`
 	Inputs              List   `tfsdk:"inputs"`
 	GenerationId        Int64  `tfsdk:"generation_id"`
-	AckEnabled          Bool   `tfsdk:"ack_enabled"`
-	BatchTimeoutSeconds Int64  `tfsdk:"batch_timeout_secs"`
-	Encoding            String `tfsdk:"encoding"`
-	Compression         String `tfsdk:"compression"`
-	ContainerName       String `tfsdk:"container_name"`
-	ConnectionString    String `tfsdk:"connection_string"`
-	Prefix              String `tfsdk:"prefix"`
+	AckEnabled          Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	BatchTimeoutSeconds Int64  `tfsdk:"batch_timeout_secs" user_config:"true"`
+	Encoding            String `tfsdk:"encoding" user_config:"true"`
+	Compression         String `tfsdk:"compression" user_config:"true"`
+	ContainerName       String `tfsdk:"container_name" user_config:"true"`
+	ConnectionString    String `tfsdk:"connection_string" user_config:"true"`
+	Prefix              String `tfsdk:"prefix" user_config:"true"`
 }
 
 func AzureBlobStorageResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/blackhole.go
+++ b/internal/provider/models/destinations/blackhole.go
@@ -16,7 +16,7 @@ type BlackholeDestinationModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	AckEnabled   Bool   `tfsdk:"ack_enabled"`
+	AckEnabled   Bool   `tfsdk:"ack_enabled" user_config:"true"`
 }
 
 func BlackholeDestinationResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/datadog_logs.go
+++ b/internal/provider/models/destinations/datadog_logs.go
@@ -15,12 +15,12 @@ type DatadogLogsDestinationModel struct {
 	PipelineId   String `tfsdk:"pipeline_id"`
 	Title        String `tfsdk:"title"`
 	Description  String `tfsdk:"description"`
-	ApiKey       String `tfsdk:"api_key"`
-	Site         String `tfsdk:"site"`
-	Compression  String `tfsdk:"compression"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	AckEnabled   Bool   `tfsdk:"ack_enabled"`
+	ApiKey       String `tfsdk:"api_key" user_config:"true"`
+	Site         String `tfsdk:"site" user_config:"true"`
+	Compression  String `tfsdk:"compression" user_config:"true"`
+	AckEnabled   Bool   `tfsdk:"ack_enabled" user_config:"true"`
 }
 
 func DatadogLogsDestinationResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/datadog_metrics.go
+++ b/internal/provider/models/destinations/datadog_metrics.go
@@ -15,11 +15,11 @@ type DatadogMetricsDestinationModel struct {
 	PipelineId   String `tfsdk:"pipeline_id"`
 	Title        String `tfsdk:"title"`
 	Description  String `tfsdk:"description"`
-	ApiKey       String `tfsdk:"api_key"`
-	Site         String `tfsdk:"site"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	AckEnabled   Bool   `tfsdk:"ack_enabled"`
+	ApiKey       String `tfsdk:"api_key" user_config:"true"`
+	Site         String `tfsdk:"site" user_config:"true"`
+	AckEnabled   Bool   `tfsdk:"ack_enabled" user_config:"true"`
 }
 
 func DatadogMetricsDestinationResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/gcp_cloud_storage.go
+++ b/internal/provider/models/destinations/gcp_cloud_storage.go
@@ -2,6 +2,7 @@ package destinations
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -21,13 +22,13 @@ type GcpCloudStorageDestinationModel struct {
 	Description         String `tfsdk:"description"`
 	Inputs              List   `tfsdk:"inputs"`
 	GenerationId        Int64  `tfsdk:"generation_id"`
-	Encoding            String `tfsdk:"encoding"`
-	Bucket              String `tfsdk:"bucket"`
-	Compression         String `tfsdk:"compression"`
-	Prefix              String `tfsdk:"prefix"`
-	Auth                Object `tfsdk:"auth"`
-	AckEnabled          Bool   `tfsdk:"ack_enabled"`
-	BatchTimeoutSeconds Int64  `tfsdk:"batch_timeout_secs"`
+	Encoding            String `tfsdk:"encoding" user_config:"true"`
+	Bucket              String `tfsdk:"bucket" user_config:"true"`
+	Compression         String `tfsdk:"compression" user_config:"true"`
+	BucketPrefix        String `tfsdk:"bucket_prefix" user_config:"true"`
+	Auth                Object `tfsdk:"auth" user_config:"true"`
+	AckEnabled          Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	BatchTimeoutSeconds Int64  `tfsdk:"batch_timeout_secs" user_config:"true"`
 }
 
 func GcpCloudStorageResourceSchema() schema.Schema {
@@ -59,7 +60,7 @@ func GcpCloudStorageResourceSchema() schema.Schema {
 					stringvalidator.OneOf("gzip", "none"),
 				},
 			},
-			"prefix": schema.StringAttribute{
+			"bucket_prefix": schema.StringAttribute{
 				Optional:    true,
 				Computed:    false,
 				Description: "The prefix applied to the bucket name, giving the appearance of having directories.",
@@ -107,7 +108,7 @@ func GcpCloudStorageDestinationFromModel(plan *GcpCloudStorageDestinationModel, 
 				"encoding":           plan.Encoding.ValueString(),
 				"bucket":             plan.Bucket.ValueString(),
 				"compression":        plan.Compression.ValueString(),
-				"bucket_prefix":      plan.Prefix.ValueString(),
+				"bucket_prefix":      plan.BucketPrefix.ValueString(),
 			},
 		},
 	}
@@ -140,6 +141,10 @@ func GcpCloudStorageDestinationToModel(plan *GcpCloudStorageDestinationModel, co
 	plan.Inputs = SliceToStringListValue(component.Inputs)
 	plan.AckEnabled = BoolValue(component.UserConfig["ack_enabled"].(bool))
 	plan.Compression = StringValue(component.UserConfig["compression"].(string))
+	plan.Encoding = StringValue(component.UserConfig["encoding"].(string))
+	plan.BucketPrefix = StringValue(component.UserConfig["bucket_prefix"].(string))
+	plan.Bucket = StringValue(component.UserConfig["bucket"].(string))
+	plan.BatchTimeoutSeconds = Int64Value(int64(component.UserConfig["batch_timeout_secs"].(float64)))
 
 	authType, _ := component.UserConfig["auth"].(string)
 	plan.Auth = basetypes.NewObjectValueMust(

--- a/internal/provider/models/destinations/honeycomb_logs.go
+++ b/internal/provider/models/destinations/honeycomb_logs.go
@@ -17,9 +17,9 @@ type HoneycombLogsDestinationModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	AckEnabled   Bool   `tfsdk:"ack_enabled"`
-	DataSet      String `tfsdk:"dataset"`
-	ApiKey       String `tfsdk:"api_key"`
+	AckEnabled   Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	DataSet      String `tfsdk:"dataset" user_config:"true"`
+	ApiKey       String `tfsdk:"api_key" user_config:"true"`
 }
 
 func HoneycombLogsResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/kafka.go
+++ b/internal/provider/models/destinations/kafka.go
@@ -24,14 +24,14 @@ type KafkaDestinationModel struct {
 	Description   String `tfsdk:"description"`
 	Inputs        List   `tfsdk:"inputs"`
 	GenerationId  Int64  `tfsdk:"generation_id"`
-	Encoding      String `tfsdk:"encoding"`
-	Compression   String `tfsdk:"compression"`
-	EventKeyField String `tfsdk:"event_key_field"`
-	Brokers       List   `tfsdk:"brokers"`
-	Topic         String `tfsdk:"topic"`
-	TLSEnabled    Bool   `tfsdk:"tls_enabled"`
-	SASL          Object `tfsdk:"sasl"`
-	AckEnabled    Bool   `tfsdk:"ack_enabled"`
+	Encoding      String `tfsdk:"encoding" user_config:"true"`
+	Compression   String `tfsdk:"compression" user_config:"true"`
+	EventKeyField String `tfsdk:"event_key_field" user_config:"true"`
+	Brokers       List   `tfsdk:"brokers" user_config:"true"`
+	Topic         String `tfsdk:"topic" user_config:"true"`
+	TLSEnabled    Bool   `tfsdk:"tls_enabled" user_config:"true"`
+	SASL          Object `tfsdk:"sasl" user_config:"true"`
+	AckEnabled    Bool   `tfsdk:"ack_enabled" user_config:"true"`
 }
 
 func KafkaDestinationResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/mezmo.go
+++ b/internal/provider/models/destinations/mezmo.go
@@ -23,12 +23,12 @@ type MezmoDestinationModel struct {
 	Description           String `tfsdk:"description"`
 	Inputs                List   `tfsdk:"inputs"`
 	GenerationId          Int64  `tfsdk:"generation_id"`
-	AckEnabled            Bool   `tfsdk:"ack_enabled"`
-	Host                  String `tfsdk:"host"`
-	IngestionKey          String `tfsdk:"ingestion_key"`
-	Query                 Object `tfsdk:"query"`
-	LogConstructionScheme String `tfsdk:"log_construction_scheme"`
-	ExplicitSchemeOptions Object `tfsdk:"explicit_scheme_options"`
+	AckEnabled            Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	Host                  String `tfsdk:"host" user_config:"true"`
+	IngestionKey          String `tfsdk:"ingestion_key" user_config:"true"`
+	Query                 Object `tfsdk:"query" user_config:"true"`
+	LogConstructionScheme String `tfsdk:"log_construction_scheme" user_config:"true"`
+	ExplicitSchemeOptions Object `tfsdk:"explicit_scheme_options" user_config:"true"`
 }
 
 var log_construction_schemes = map[string]string{
@@ -226,6 +226,8 @@ func MezmoDestinationToModel(plan *MezmoDestinationModel, component *Destination
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.Inputs = SliceToStringListValue(component.Inputs)
 	plan.AckEnabled = BoolValue(component.UserConfig["ack_enabled"].(bool))
+	plan.Host = StringValue(component.UserConfig["mezmo_host"].(string))
+	plan.IngestionKey = StringValue(component.UserConfig["ingestion_key"].(string))
 
 	if component.UserConfig["query"] != nil {
 		component_map, _ := component.UserConfig["query"].(map[string]any)

--- a/internal/provider/models/destinations/new_relic.go
+++ b/internal/provider/models/destinations/new_relic.go
@@ -18,10 +18,10 @@ type NewRelicDestinationModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	AckEnabled   Bool   `tfsdk:"ack_enabled"`
-	Api          String `tfsdk:"api"`
-	AccountId    String `tfsdk:"account_id"`
-	LicenseKey   String `tfsdk:"license_key"`
+	AckEnabled   Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	Api          String `tfsdk:"api" user_config:"true"`
+	AccountId    String `tfsdk:"account_id" user_config:"true"`
+	LicenseKey   String `tfsdk:"license_key" user_config:"true"`
 }
 
 func NewRelicDestinationResourceSchema() schema.Schema {

--- a/internal/provider/models/destinations/s3.go
+++ b/internal/provider/models/destinations/s3.go
@@ -21,14 +21,14 @@ type S3DestinationModel struct {
 	Description         String `tfsdk:"description"`
 	Inputs              List   `tfsdk:"inputs"`
 	GenerationId        Int64  `tfsdk:"generation_id"`
-	AckEnabled          Bool   `tfsdk:"ack_enabled"`
-	BatchTimeoutSeconds Int64  `tfsdk:"batch_timeout_secs"`
-	Auth                Object `tfsdk:"auth"`
-	Region              String `tfsdk:"region"`
-	Bucket              String `tfsdk:"bucket"`
-	Prefix              String `tfsdk:"prefix"`
-	Encoding            String `tfsdk:"encoding"`
-	Compression         String `tfsdk:"compression"`
+	AckEnabled          Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	BatchTimeoutSeconds Int64  `tfsdk:"batch_timeout_secs" user_config:"true"`
+	Auth                Object `tfsdk:"auth" user_config:"true"`
+	Region              String `tfsdk:"region" user_config:"true"`
+	Bucket              String `tfsdk:"bucket" user_config:"true"`
+	Prefix              String `tfsdk:"prefix" user_config:"true"`
+	Encoding            String `tfsdk:"encoding" user_config:"true"`
+	Compression         String `tfsdk:"compression" user_config:"true"`
 }
 
 func S3DestinationResourceSchema() schema.Schema {
@@ -134,10 +134,10 @@ func S3DestinationToModel(plan *S3DestinationModel, component *Destination) {
 	plan.AckEnabled = BoolValue(component.UserConfig["ack_enabled"].(bool))
 	plan.BatchTimeoutSeconds = Int64Value(int64(component.UserConfig["batch_timeout_secs"].(float64)))
 
-	values, _ := component.UserConfig["auth"].(map[string]string)
+	values, _ := component.UserConfig["auth"].(map[string]any)
 	if len(values) > 0 {
 		types := plan.Auth.AttributeTypes(context.Background())
-		plan.Auth = basetypes.NewObjectValueMust(types, MapStringsToMapValues(values))
+		plan.Auth = basetypes.NewObjectValueMust(types, MapAnyToMapValues(values))
 	}
 
 	plan.Region = StringValue(component.UserConfig["region"].(string))

--- a/internal/provider/models/destinations/splunk_hec_logs.go
+++ b/internal/provider/models/destinations/splunk_hec_logs.go
@@ -24,16 +24,16 @@ type SplunkHecLogsDestinationModel struct {
 	Description          String `tfsdk:"description"`
 	Inputs               List   `tfsdk:"inputs"`
 	GenerationId         Int64  `tfsdk:"generation_id"`
-	AckEnabled           Bool   `tfsdk:"ack_enabled"`
-	Compression          String `tfsdk:"compression"`
-	Endpoint             String `tfsdk:"endpoint"`
-	Token                String `tfsdk:"token"`
-	HostField            String `tfsdk:"host_field"`
-	TimestampField       String `tfsdk:"timestamp_field"`
-	TlsVerifyCertificate Bool   `tfsdk:"tls_verify_certificate"`
-	Source               Object `tfsdk:"source"`
-	SourceType           Object `tfsdk:"source_type"`
-	Index                Object `tfsdk:"index"`
+	AckEnabled           Bool   `tfsdk:"ack_enabled" user_config:"true"`
+	Compression          String `tfsdk:"compression" user_config:"true"`
+	Endpoint             String `tfsdk:"endpoint" user_config:"true"`
+	Token                String `tfsdk:"token" user_config:"true"`
+	HostField            String `tfsdk:"host_field" user_config:"true"`
+	TimestampField       String `tfsdk:"timestamp_field" user_config:"true"`
+	TlsVerifyCertificate Bool   `tfsdk:"tls_verify_certificate" user_config:"true"`
+	Source               Object `tfsdk:"source" user_config:"true"`
+	SourceType           Object `tfsdk:"source_type" user_config:"true"`
+	Index                Object `tfsdk:"index" user_config:"true"`
 }
 
 var splunkValueTypeAttributes = map[string]schema.Attribute{
@@ -161,7 +161,7 @@ func splunkValueTypeFromModel(
 	dd *diag.Diagnostics,
 ) {
 	if !planValue.IsNull() {
-		m, _ := MapValuesToMapStrings(*planValue, *dd)
+		m := MapValuesToMapAny(*planValue, dd)
 		target := component.UserConfig[configName].(map[string]any)
 		if m["field"] != "" {
 			target["value_type"] = "field"

--- a/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
@@ -1,10 +1,11 @@
 package destinations
 
 import (
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestGcpCloudStorageSinkResource(t *testing.T) {
@@ -107,13 +108,13 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						inputs = ["abc"]
 						pipeline_id = "pipeline-id"
 						bucket = "test_bucket"
-						prefix = ""
+						bucket_prefix = ""
 						auth = {
 							type = "api_key"
 							value = "key"
 						}
 					}`,
-				ExpectError: regexp.MustCompile("Attribute prefix string length must be at least 1"),
+				ExpectError: regexp.MustCompile("Attribute bucket_prefix string length must be at least 1"),
 			},
 			{
 				Config: GetProviderConfig() + `
@@ -160,7 +161,7 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						encoding = "json"
 						compression = "gzip"
 						bucket = "test_bucket"
-						prefix = "prefix"
+						bucket_prefix = "bucket_prefix"
 						auth = {
 							type = "api_key"
 							value = "key"
@@ -179,7 +180,7 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						"encoding":      "json",
 						"compression":   "gzip",
 						"bucket":        "test_bucket",
-						"prefix":        "prefix",
+						"bucket_prefix": "bucket_prefix",
 						"auth.type":     "api_key",
 						"auth.value":    "key",
 					}),
@@ -199,7 +200,7 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						encoding = "text"
 						compression = "none"
 						bucket = "new_bucket"
-						prefix = "newprefix"
+						bucket_prefix = "newprefix"
 						ack_enabled = false
 						auth = {
 							type = "credentials_json"
@@ -219,7 +220,7 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						"encoding":      "text",
 						"compression":   "none",
 						"bucket":        "new_bucket",
-						"prefix":        "newprefix",
+						"bucket_prefix": "newprefix",
 						"auth.type":     "credentials_json",
 						"auth.value":    "{}",
 					}),

--- a/internal/provider/models/modelutils/parsers.go
+++ b/internal/provider/models/modelutils/parsers.go
@@ -34,7 +34,7 @@ var VRL_PARSERS = map[string]string{
 	"user_agent_parser":       "parse_user_agent",
 }
 
-var VRL_PARSES_WITH_REQUIRED_OPTIONS = []string{
+var VRL_PARSERS_WITH_REQUIRED_OPTIONS = []string{
 	"apache_log",
 	"grok_parser",
 	"regex_parser",

--- a/internal/provider/models/processors/compact_fields.go
+++ b/internal/provider/models/processors/compact_fields.go
@@ -21,9 +21,9 @@ type CompactFieldsProcessorModel struct {
 	Description   String `tfsdk:"description"`
 	Inputs        List   `tfsdk:"inputs"`
 	GenerationId  Int64  `tfsdk:"generation_id"`
-	Fields        List   `tfsdk:"fields"`
-	CompactArray  Bool   `tfsdk:"compact_array"`
-	CompactObject Bool   `tfsdk:"compact_object"`
+	Fields        List   `tfsdk:"fields" user_config:"true"`
+	CompactArray  Bool   `tfsdk:"compact_array" user_config:"true"`
+	CompactObject Bool   `tfsdk:"compact_object" user_config:"true"`
 }
 
 func CompactFieldsProcessorResourceSchema() schema.Schema {
@@ -115,9 +115,9 @@ func CompactFieldsProcessorToModel(plan *CompactFieldsProcessorModel, component 
 	}
 
 	plan.Fields = modelutils.SliceToStringListValue(component.UserConfig["fields"].([]any))
-	options, _ := component.UserConfig["options"].(map[string]bool)
+	options, _ := component.UserConfig["options"].(map[string]any)
 	if options != nil {
-		plan.CompactArray = BoolValue(options["compact_array"])
-		plan.CompactObject = BoolValue(options["compact_object"])
+		plan.CompactArray = BoolValue(options["compact_array"].(bool))
+		plan.CompactObject = BoolValue(options["compact_object"].(bool))
 	}
 }

--- a/internal/provider/models/processors/decrypt_fields.go
+++ b/internal/provider/models/processors/decrypt_fields.go
@@ -18,11 +18,11 @@ type DecryptFieldsProcessorModel struct {
 	Description    String `tfsdk:"description"`
 	Inputs         List   `tfsdk:"inputs"`
 	GenerationId   Int64  `tfsdk:"generation_id"`
-	Field          String `tfsdk:"field"`
-	Algorithm      String `tfsdk:"algorithm"`
-	Key            String `tfsdk:"key"`
-	IvField        String `tfsdk:"iv_field"`
-	DecodeRawBytes Bool   `tfsdk:"decode_raw_bytes"`
+	Field          String `tfsdk:"field" user_config:"true"`
+	Algorithm      String `tfsdk:"algorithm" user_config:"true"`
+	Key            String `tfsdk:"key" user_config:"true"`
+	IvField        String `tfsdk:"iv_field" user_config:"true"`
+	DecodeRawBytes Bool   `tfsdk:"decode_raw_bytes" user_config:"true"`
 }
 
 func DecryptFieldsProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/processors/dedupe.go
+++ b/internal/provider/models/processors/dedupe.go
@@ -21,9 +21,9 @@ type DedupeProcessorModel struct {
 	Description    String `tfsdk:"description"`
 	Inputs         List   `tfsdk:"inputs"`
 	GenerationId   Int64  `tfsdk:"generation_id"`
-	Fields         List   `tfsdk:"fields"`
-	NumberOfEvents Int64  `tfsdk:"number_of_events"`
-	ComparisonType String `tfsdk:"comparison_type"`
+	Fields         List   `tfsdk:"fields" user_config:"true"`
+	NumberOfEvents Int64  `tfsdk:"number_of_events" user_config:"true"`
+	ComparisonType String `tfsdk:"comparison_type" user_config:"true"`
 }
 
 func DedupeProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/processors/drop_fields.go
+++ b/internal/provider/models/processors/drop_fields.go
@@ -18,7 +18,7 @@ type DropFieldsProcessorModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Fields       List   `tfsdk:"fields"`
+	Fields       List   `tfsdk:"fields" user_config:"true"`
 }
 
 func DropFieldsProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/processors/encrypt_fields.go
+++ b/internal/provider/models/processors/encrypt_fields.go
@@ -18,11 +18,11 @@ type EncryptFieldsProcessorModel struct {
 	Description    String `tfsdk:"description"`
 	Inputs         List   `tfsdk:"inputs"`
 	GenerationId   Int64  `tfsdk:"generation_id"`
-	Field          String `tfsdk:"field"`
-	Algorithm      String `tfsdk:"algorithm"`
-	Key            String `tfsdk:"key"`
-	IvField        String `tfsdk:"iv_field"`
-	EncodeRawBytes Bool   `tfsdk:"encode_raw_bytes"`
+	Field          String `tfsdk:"field" user_config:"true"`
+	Algorithm      String `tfsdk:"algorithm" user_config:"true"`
+	Key            String `tfsdk:"key" user_config:"true"`
+	IvField        String `tfsdk:"iv_field" user_config:"true"`
+	EncodeRawBytes Bool   `tfsdk:"encode_raw_bytes" user_config:"true"`
 }
 
 func EncryptFieldsProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/processors/flatten_fields.go
+++ b/internal/provider/models/processors/flatten_fields.go
@@ -20,8 +20,8 @@ type FlattenFieldsProcessorModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Fields       List   `tfsdk:"fields"`
-	Delimiter    String `tfsdk:"delimiter"`
+	Fields       List   `tfsdk:"fields" user_config:"true"`
+	Delimiter    String `tfsdk:"delimiter" user_config:"true"`
 }
 
 func FlattenFieldsProcessorResourceSchema() schema.Schema {
@@ -95,9 +95,9 @@ func FlattenFieldsProcessorToModel(plan *FlattenFieldsProcessorModel, component 
 	}
 
 	if component.UserConfig["fields"] != nil {
-		fields, _ := component.UserConfig["fields"].(map[string]string)
+		fields, _ := component.UserConfig["fields"].([]any)
 		if len(fields) > 0 {
-			plan.Fields = modelutils.SliceToStringListValue(component.UserConfig["fields"].([]any))
+			plan.Fields = modelutils.SliceToStringListValue(fields)
 		}
 	}
 

--- a/internal/provider/models/processors/reduce.go
+++ b/internal/provider/models/processors/reduce.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
 	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
@@ -23,11 +24,11 @@ type ReduceProcessorModel struct {
 	Description     StringValue `tfsdk:"description"`
 	Inputs          ListValue   `tfsdk:"inputs"`
 	GenerationId    Int64Value  `tfsdk:"generation_id"`
-	DurationMs      Int64Value  `tfsdk:"duration_ms"`
-	GroupBy         ListValue   `tfsdk:"group_by"`
-	DateFormats     ListValue   `tfsdk:"date_formats"`
-	MergeStrategies ListValue   `tfsdk:"merge_strategies"`
-	FlushCondition  ObjectValue `tfsdk:"flush_condition"`
+	DurationMs      Int64Value  `tfsdk:"duration_ms" user_config:"true"`
+	GroupBy         ListValue   `tfsdk:"group_by" user_config:"true"`
+	DateFormats     ListValue   `tfsdk:"date_formats" user_config:"true"`
+	MergeStrategies ListValue   `tfsdk:"merge_strategies" user_config:"true"`
+	FlushCondition  ObjectValue `tfsdk:"flush_condition" user_config:"true"`
 }
 
 func ReduceProcessorResourceSchema() schema.Schema {
@@ -155,18 +156,18 @@ func ReduceProcessorFromModel(plan *ReduceProcessorModel, previousState *ReduceP
 	}
 
 	if !plan.DateFormats.IsNull() {
-		dateFormats := make([]map[string]string, 0)
+		dateFormats := make([]map[string]any, 0)
 		for _, v := range plan.DateFormats.Elements() {
-			obj, _ := MapValuesToMapStrings(v, dd)
+			obj := MapValuesToMapAny(v, &dd)
 			dateFormats = append(dateFormats, obj)
 		}
 		component.UserConfig["date_formats"] = dateFormats
 	}
 
 	if !plan.MergeStrategies.IsNull() {
-		mergeStrategies := make([]map[string]string, 0)
+		mergeStrategies := make([]map[string]any, 0)
 		for _, v := range plan.MergeStrategies.Elements() {
-			obj, _ := MapValuesToMapStrings(v, dd)
+			obj := MapValuesToMapAny(v, &dd)
 			mergeStrategies = append(mergeStrategies, obj)
 		}
 		component.UserConfig["merge_strategies"] = mergeStrategies
@@ -231,6 +232,7 @@ func unwindConditionalFromModel(v attr.Value) map[string]any {
 }
 
 func ReduceProcessorToModel(plan *ReduceProcessorModel, component *Processor) {
+	// plan.ClearFields()
 	plan.Id = NewStringValue(component.Id)
 	if component.Title != "" {
 		plan.Title = NewStringValue(component.Title)

--- a/internal/provider/models/processors/route.go
+++ b/internal/provider/models/processors/route.go
@@ -21,7 +21,7 @@ type RouteProcessorModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Conditionals List   `tfsdk:"conditionals"`
+	Conditionals List   `tfsdk:"conditionals" user_config:"true"`
 }
 
 var RouteProcessorName = "route"

--- a/internal/provider/models/processors/sample.go
+++ b/internal/provider/models/processors/sample.go
@@ -23,8 +23,8 @@ type SampleProcessorModel struct {
 	Description   String `tfsdk:"description"`
 	Inputs        List   `tfsdk:"inputs"`
 	GenerationId  Int64  `tfsdk:"generation_id"`
-	Rate          Int64  `tfsdk:"rate"`
-	AlwaysInclude Object `tfsdk:"always_include"`
+	Rate          Int64  `tfsdk:"rate" user_config:"true"`
+	AlwaysInclude Object `tfsdk:"always_include" user_config:"true"`
 }
 
 func SampleProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/processors/script_execution.go
+++ b/internal/provider/models/processors/script_execution.go
@@ -17,7 +17,7 @@ type ScriptExecutionProcessorModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Script       String `tfsdk:"script"`
+	Script       String `tfsdk:"script" user_config:"true"`
 }
 
 func ScriptExecutionProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/processors/unroll.go
+++ b/internal/provider/models/processors/unroll.go
@@ -18,8 +18,8 @@ type UnrollProcessorModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Field        String `tfsdk:"field"`
-	ValuesOnly   Bool   `tfsdk:"values_only"`
+	Field        String `tfsdk:"field" user_config:"true"`
+	ValuesOnly   Bool   `tfsdk:"values_only" user_config:"true"`
 }
 
 func UnrollProcessorResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/agent.go
+++ b/internal/provider/models/sources/agent.go
@@ -15,8 +15,8 @@ type AgentSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func AgentSourceResourceSchema() schema.Schema {
@@ -72,9 +72,8 @@ func AgentSourceToModel(plan *AgentSourceModel, component *Source) {
 	if component.Description != "" {
 		plan.Description = StringValue(component.Description)
 	}
-	if component.UserConfig["format"] != nil {
-		captureMetadata, _ := component.UserConfig["capture_metadata"].(bool)
-		plan.CaptureMetadata = BoolValue(captureMetadata)
+	if component.UserConfig["capture_metadata"] != nil {
+		plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	}
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.GatewayRouteId = StringValue(component.GatewayRouteId)

--- a/internal/provider/models/sources/azure_event_hub.go
+++ b/internal/provider/models/sources/azure_event_hub.go
@@ -18,11 +18,11 @@ type AzureEventHubSourceModel struct {
 	Title            String `tfsdk:"title"`
 	Description      String `tfsdk:"description"`
 	GenerationId     Int64  `tfsdk:"generation_id"`
-	Decoding         String `tfsdk:"decoding"`
-	ConnectionString String `tfsdk:"connection_string"`
-	Namespace        String `tfsdk:"namespace"`
-	GroupId          String `tfsdk:"group_id"`
-	Topics           List   `tfsdk:"topics"`
+	Decoding         String `tfsdk:"decoding" user_config:"true"`
+	ConnectionString String `tfsdk:"connection_string" user_config:"true"`
+	Namespace        String `tfsdk:"namespace" user_config:"true"`
+	GroupId          String `tfsdk:"group_id" user_config:"true"`
+	Topics           List   `tfsdk:"topics" user_config:"true"`
 }
 
 func AzureEventHubSourceResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/fluent.go
+++ b/internal/provider/models/sources/fluent.go
@@ -18,9 +18,9 @@ type FluentSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	Decoding        String `tfsdk:"decoding"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	Decoding        String `tfsdk:"decoding" user_config:"true"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func FluentSourceResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/http.go
+++ b/internal/provider/models/sources/http.go
@@ -18,9 +18,9 @@ type HttpSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	Decoding        String `tfsdk:"decoding"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	Decoding        String `tfsdk:"decoding" user_config:"true"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func HttpSourceResourceSchema() schema.Schema {
@@ -89,12 +89,8 @@ func HttpSourceToModel(plan *HttpSourceModel, component *Source) {
 	if component.Description != "" {
 		plan.Description = StringValue(component.Description)
 	}
-	if component.UserConfig["format"] != nil {
-		decoding, _ := component.UserConfig["decoding"].(string)
-		plan.Decoding = StringValue(decoding)
-		captureMetadata, _ := component.UserConfig["capture_metadata"].(bool)
-		plan.CaptureMetadata = BoolValue(captureMetadata)
-	}
+	plan.Decoding = StringValue(component.UserConfig["decoding"].(string))
+	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
 }

--- a/internal/provider/models/sources/kafka.go
+++ b/internal/provider/models/sources/kafka.go
@@ -22,12 +22,12 @@ type KafkaSourceModel struct {
 	Title        String `tfsdk:"title"`
 	Description  String `tfsdk:"description"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Brokers      List   `tfsdk:"brokers"`
-	Topics       List   `tfsdk:"topics"`
-	GroupId      String `tfsdk:"group_id"`
-	TLSEnabled   Bool   `tfsdk:"tls_enabled"`
-	SASL         Object `tfsdk:"sasl"`
-	Decoding     String `tfsdk:"decoding"`
+	Brokers      List   `tfsdk:"brokers" user_config:"true"`
+	Topics       List   `tfsdk:"topics" user_config:"true"`
+	GroupId      String `tfsdk:"group_id" user_config:"true"`
+	TLSEnabled   Bool   `tfsdk:"tls_enabled" user_config:"true"`
+	SASL         Object `tfsdk:"sasl" user_config:"true"`
+	Decoding     String `tfsdk:"decoding" user_config:"true"`
 }
 
 func KafkaSourceResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/kinesis_firehose.go
+++ b/internal/provider/models/sources/kinesis_firehose.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -17,10 +18,10 @@ type KinesisFirehoseSourceModel struct {
 	PipelineId      String `tfsdk:"pipeline_id"`
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
-	Decoding        String `tfsdk:"decoding"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	Decoding        String `tfsdk:"decoding" user_config:"true"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func KinesisFirehoseSourceResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/logstash.go
+++ b/internal/provider/models/sources/logstash.go
@@ -18,9 +18,9 @@ type LogStashSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	Format          String `tfsdk:"format"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	Format          String `tfsdk:"format" user_config:"true"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func LogStashSourceResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/prometheus_remote_write.go
+++ b/internal/provider/models/sources/prometheus_remote_write.go
@@ -15,8 +15,8 @@ type PrometheusRemoteWriteSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func PrometheusRemoteWriteSourceResourceSchema() schema.Schema {
@@ -72,9 +72,8 @@ func PrometheusRemoteWriteSourceToModel(plan *PrometheusRemoteWriteSourceModel, 
 	if component.Description != "" {
 		plan.Description = StringValue(component.Description)
 	}
-	if component.UserConfig["format"] != nil {
-		captureMetadata, _ := component.UserConfig["capture_metadata"].(bool)
-		plan.CaptureMetadata = BoolValue(captureMetadata)
+	if component.UserConfig["capture_metadata"] != nil {
+		plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	}
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.GatewayRouteId = StringValue(component.GatewayRouteId)

--- a/internal/provider/models/sources/s3.go
+++ b/internal/provider/models/sources/s3.go
@@ -20,11 +20,11 @@ type S3SourceModel struct {
 	PipelineId   String `tfsdk:"pipeline_id"`
 	Title        String `tfsdk:"title"`
 	Description  String `tfsdk:"description"`
-	Auth         Object `tfsdk:"auth"`
-	Region       String `tfsdk:"region"`
-	SqsQueueUrl  String `tfsdk:"sqs_queue_url"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	Compression  String `tfsdk:"compression"`
+	Auth         Object `tfsdk:"auth" user_config:"true"`
+	Region       String `tfsdk:"region" user_config:"true"`
+	SqsQueueUrl  String `tfsdk:"sqs_queue_url" user_config:"true"`
+	Compression  String `tfsdk:"compression" user_config:"true"`
 }
 
 func S3SourceResourceSchema() schema.Schema {
@@ -118,10 +118,10 @@ func S3SourceToModel(plan *S3SourceModel, component *Source) {
 		plan.Compression = StringValue(value)
 	}
 	if component.UserConfig["auth"] != nil {
-		values, _ := component.UserConfig["auth"].(map[string]string)
+		values, _ := component.UserConfig["auth"].(map[string]any)
 		if len(values) > 0 {
 			types := plan.Auth.AttributeTypes(context.Background())
-			plan.Auth = basetypes.NewObjectValueMust(types, modelutils.MapStringsToMapValues(values))
+			plan.Auth = basetypes.NewObjectValueMust(types, modelutils.MapAnyToMapValues(values))
 		}
 	}
 

--- a/internal/provider/models/sources/splunk-hec.go
+++ b/internal/provider/models/sources/splunk-hec.go
@@ -15,8 +15,8 @@ type SplunkHecSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	CaptureMetadata Bool   `tfsdk:"capture_metadata"`
 	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 func SplunkHecSourceResourceSchema() schema.Schema {

--- a/internal/provider/models/sources/sqs.go
+++ b/internal/provider/models/sources/sqs.go
@@ -19,9 +19,9 @@ type SQSSourceModel struct {
 	Title        String `tfsdk:"title"`
 	Description  String `tfsdk:"description"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	QueueUrl     String `tfsdk:"queue_url"`
-	Auth         Object `tfsdk:"auth"`
-	Region       String `tfsdk:"region"`
+	QueueUrl     String `tfsdk:"queue_url" user_config:"true"`
+	Auth         Object `tfsdk:"auth" user_config:"true"`
+	Region       String `tfsdk:"region" user_config:"true"`
 }
 
 func SQSSourceResourceSchema() schema.Schema {
@@ -108,10 +108,10 @@ func SQSSourceToModel(plan *SQSSourceModel, component *Source) {
 	plan.QueueUrl = StringValue(queueUrl)
 
 	if component.UserConfig["auth"] != nil {
-		values, _ := component.UserConfig["auth"].(map[string]string)
+		values, _ := component.UserConfig["auth"].(map[string]any)
 		if len(values) > 0 {
 			types := plan.Auth.AttributeTypes(context.Background())
-			plan.Auth = basetypes.NewObjectValueMust(types, modelutils.MapStringsToMapValues(values))
+			plan.Auth = basetypes.NewObjectValueMust(types, modelutils.MapAnyToMapValues(values))
 		}
 	}
 

--- a/internal/provider/processor_resource.go
+++ b/internal/provider/processor_resource.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
 	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/processors"
 )
 
@@ -67,6 +69,11 @@ func (r *ProcessorResource[T]) Create(ctx context.Context, req resource.CreateRe
 	if setDiagnosticsHasError(dd, &resp.Diagnostics) {
 		return
 	}
+
+	if os.Getenv("DEBUG_PROCESSOR") == "1" {
+		PrintJSON("----- Processor TO Create api ---", component)
+	}
+
 	stored, err := r.client.CreateProcessor(r.getPipelineIdFunc(&plan).ValueString(), component)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -75,6 +82,12 @@ func (r *ProcessorResource[T]) Create(ctx context.Context, req resource.CreateRe
 		)
 		return
 	}
+
+	if os.Getenv("DEBUG_PROCESSOR") == "1" {
+		PrintJSON("----- Processor FROM Create api ---", stored)
+	}
+
+	NullifyPlanFields(&plan, r.getSchemaFunc())
 
 	r.toModelFunc(&plan, stored)
 	diags = resp.State.Set(ctx, plan)
@@ -124,6 +137,8 @@ func (r *ProcessorResource[T]) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	NullifyPlanFields(&state, r.getSchemaFunc())
+
 	r.toModelFunc(&state, component)
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -145,6 +160,11 @@ func (r *ProcessorResource[T]) Update(ctx context.Context, req resource.UpdateRe
 	if setDiagnosticsHasError(dd, &resp.Diagnostics) {
 		return
 	}
+
+	if os.Getenv("DEBUG_PROCESSOR") == "1" {
+		PrintJSON("----- Processor TO Update api ---", component)
+	}
+
 	stored, err := r.client.UpdateProcessor(r.getPipelineIdFunc(&state).ValueString(), component)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -153,6 +173,12 @@ func (r *ProcessorResource[T]) Update(ctx context.Context, req resource.UpdateRe
 		)
 		return
 	}
+
+	if os.Getenv("DEBUG_PROCESSOR") == "1" {
+		PrintJSON("----- Processor FROM Update api ---", stored)
+	}
+
+	NullifyPlanFields(&plan, r.getSchemaFunc())
 
 	r.toModelFunc(&plan, stored)
 	diags := resp.State.Set(ctx, plan)

--- a/internal/provider/providertest/utils.go
+++ b/internal/provider/providertest/utils.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 const authAccountId = "tf_test_01"
@@ -127,8 +128,9 @@ func StateHasExpectedValues(resourceName string, expected map[string]any) resour
 		}
 		attributes := resource.Primary.Attributes
 
-		// For debugging:
-		// fmt.Printf("---------- attributes ------- %+v\n", attributes)
+		if os.Getenv("DEBUG_ATTRIBUTES") == "1" {
+			modelutils.PrintJSON(fmt.Sprintf("------ %s STATE ATTRIBUTES ------", resourceName), attributes)
+		}
 
 		for expectedKey, expectedVal := range expected {
 			foundVal, state_has_key := attributes[expectedKey]

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
 	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/sources"
 )
 
@@ -66,6 +68,11 @@ func (r *SourceResource[T]) Create(ctx context.Context, req resource.CreateReque
 	if setDiagnosticsHasError(dd, &resp.Diagnostics) {
 		return
 	}
+
+	if os.Getenv("DEBUG_SOURCE") == "1" {
+		PrintJSON("----- Destination TO Create api ---", component)
+	}
+
 	stored, err := r.client.CreateSource(r.getPipelineIdFunc(&plan).ValueString(), component)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -74,6 +81,12 @@ func (r *SourceResource[T]) Create(ctx context.Context, req resource.CreateReque
 		)
 		return
 	}
+
+	if os.Getenv("DEBUG_SOURCE") == "1" {
+		PrintJSON("----- Destination FROM Create api ---", stored)
+	}
+
+	NullifyPlanFields(&plan, r.getSchemaFunc())
 
 	r.toModelFunc(&plan, stored)
 	diags = resp.State.Set(ctx, plan)
@@ -123,6 +136,8 @@ func (r *SourceResource[T]) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
+	NullifyPlanFields(&state, r.getSchemaFunc())
+
 	r.toModelFunc(&state, component)
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -145,6 +160,10 @@ func (r *SourceResource[T]) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	if os.Getenv("DEBUG_SOURCE") == "1" {
+		PrintJSON("----- Destination TO Update api ---", component)
+	}
+
 	stored, err := r.client.UpdateSource(r.getPipelineIdFunc(&state).ValueString(), component)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -153,6 +172,12 @@ func (r *SourceResource[T]) Update(ctx context.Context, req resource.UpdateReque
 		)
 		return
 	}
+
+	if os.Getenv("DEBUG_SOURCE") == "1" {
+		PrintJSON("----- Destination FROM Update api ---", stored)
+	}
+
+	NullifyPlanFields(&plan, r.getSchemaFunc())
 
 	r.toModelFunc(&plan, stored)
 	diags := resp.State.Set(ctx, plan)


### PR DESCRIPTION
The way that state is managed in Terraform is that it expects models to mirror api responses, and when an api response is received, the state is completely overwritten with that response. Our modeling does NOT match the api results directly since we break out "user_config" fields for a variety of reasons. Because of this, we need to manually update the plan/state fields with the response.  However, if we fail to update any fields, the original state values still exist (as populated by the user-inputted terraform config). This causes our tests to *think* that values in the state have also been created on the remote resource, but it's not necessarily true.

This commit adds a function that will nullify all of our user config fields prior to calling Create, Read or Update methods so that if we fail to update them with the api's response, it will error. All we need to do is use Go tags to denote which struct fields belong to `user_config:""`.

The remainder of the changes in this commit are bug fixes for things that started erroring after the fix was in place.

Ref: LOG-18104