### PR TITLE
feat: Expose models through conversion interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ terraform.tfstate
 bin/
 dist/
 modules-dev/
-/pkg/
 website/.vagrant
 website/.bundle
 website/build

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -2,7 +2,10 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -21,6 +24,30 @@ func NewPipelineResource() resource.Resource {
 
 type PipelineResource struct {
 	client client.Client
+}
+
+func (r *PipelineResource) TypeName() string {
+	return "pipeline"
+}
+
+func (r *PipelineResource) TerraformSchema() schema.Schema {
+	return PipelineResourceSchema()
+}
+
+func (r *PipelineResource) ConvertToTerraformModel(component *reflect.Value) (*reflect.Value, error) {
+	if !component.CanInterface() {
+		return nil, errors.New("component Value does not contain an interfaceable type")
+	}
+
+	pipeline, ok := component.Interface().(client.Pipeline)
+	if !ok {
+		return nil, errors.New("component Value cannot be cast to Pipeline")
+	}
+
+	var model PipelineResourceModel
+	PipelineToModel(&model, &pipeline)
+	res := reflect.ValueOf(model)
+	return &res, nil
 }
 
 // Configure implements resource.ResourceWithConfigure.

--- a/pkg/resources/convertible.go
+++ b/pkg/resources/convertible.go
@@ -1,0 +1,38 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"reflect"
+)
+
+type PipelineApiModel = client.Pipeline
+type SourceApiModel = client.Source
+type ProcessorApiModel = client.Processor
+type DestinationApiModel = client.Destination
+
+type ConvertibleResourceDef interface {
+	TypeName() string
+	TerraformSchema() schema.Schema
+	ConvertToTerraformModel(component *reflect.Value) (*reflect.Value, error)
+}
+
+func ConvertibleResources() ([]ConvertibleResourceDef, error) {
+	p := provider.MezmoProvider{}
+	terraformRes := p.Resources(context.Background())
+	convertibleRes := make([]ConvertibleResourceDef, len(terraformRes))
+	for i, tfResFn := range terraformRes {
+		tfRes := tfResFn()
+		cRes, ok := tfRes.(ConvertibleResourceDef)
+		if !ok {
+			err := errors.New(fmt.Sprintf("terraform resource %T does not implement ConvertibleResourceDef", tfRes))
+			return nil, err
+		}
+		convertibleRes[i] = cRes
+	}
+	return convertibleRes, nil
+}

--- a/pkg/resources/convertible_test.go
+++ b/pkg/resources/convertible_test.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"context"
+	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"reflect"
+	"testing"
+)
+
+func TestConvertibleResources(t *testing.T) {
+	var unmatchedResources = make(map[string]bool)
+
+	p := provider.MezmoProvider{}
+	for _, resFn := range p.Resources(context.Background()) {
+		res := resFn()
+		resTy := reflect.TypeOf(res).String()
+		unmatchedResources[resTy] = false
+	}
+
+	actual, err := ConvertibleResources()
+	if err != nil {
+		t.Errorf("Error calling ConvertibleResources: %s", err)
+		return
+	}
+	for _, convRes := range actual {
+		convResTy := reflect.TypeOf(convRes).String()
+		if _, ok := unmatchedResources[convResTy]; ok {
+			delete(unmatchedResources, convResTy)
+		} else {
+			unmatchedResources[convResTy] = true
+		}
+	}
+
+	for unmatchedType, which := range unmatchedResources {
+		if which == false {
+			t.Errorf(
+				"Terraform Resource %s does not contain corresponding Convertible Resource instance",
+				unmatchedType,
+			)
+		} else {
+			t.Errorf(
+				"Convertible Resource %s does not contain corresponding Terraform Resource",
+				unmatchedType,
+			)
+		}
+	}
+}


### PR DESCRIPTION
This commit exposes all of the pipeline node models through a public API function for use in the export project. Exposes node models implement a conversion specific interface so conversion can be generic based on the input data.

Ref: LOG-18232