### PR TITLE
chore: update module path to use correct org

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mezmo-inc/terraform-provider-mezmo
+module github.com/mezmo/terraform-provider-mezmo
 
 go 1.20
 

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/destinations"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/destinations"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type DestinationModel interface {

--- a/internal/provider/destination_resource_definitions.go
+++ b/internal/provider/destination_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/destinations"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/destinations"
 )
 
 func NewAzureBlobStorageDestinationResource() resource.Resource {

--- a/internal/provider/models/destinations/azure_blob_storage.go
+++ b/internal/provider/models/destinations/azure_blob_storage.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type AzureBlobStorageDestinationModel struct {

--- a/internal/provider/models/destinations/blackhole.go
+++ b/internal/provider/models/destinations/blackhole.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type BlackholeDestinationModel struct {

--- a/internal/provider/models/destinations/datadog_logs.go
+++ b/internal/provider/models/destinations/datadog_logs.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type DatadogLogsDestinationModel struct {

--- a/internal/provider/models/destinations/datadog_metrics.go
+++ b/internal/provider/models/destinations/datadog_metrics.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type DatadogMetricsDestinationModel struct {

--- a/internal/provider/models/destinations/elasticsearch.go
+++ b/internal/provider/models/destinations/elasticsearch.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type ElasticSearchDestinationModel struct {

--- a/internal/provider/models/destinations/gcp_cloud_storage.go
+++ b/internal/provider/models/destinations/gcp_cloud_storage.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type GcpCloudStorageDestinationModel struct {

--- a/internal/provider/models/destinations/honeycomb_logs.go
+++ b/internal/provider/models/destinations/honeycomb_logs.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type HoneycombLogsDestinationModel struct {

--- a/internal/provider/models/destinations/http.go
+++ b/internal/provider/models/destinations/http.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type HttpDestinationModel struct {

--- a/internal/provider/models/destinations/kafka.go
+++ b/internal/provider/models/destinations/kafka.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type KafkaDestinationModel struct {

--- a/internal/provider/models/destinations/loki.go
+++ b/internal/provider/models/destinations/loki.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type LokiDestinationModel struct {

--- a/internal/provider/models/destinations/mezmo.go
+++ b/internal/provider/models/destinations/mezmo.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type MezmoDestinationModel struct {

--- a/internal/provider/models/destinations/new_relic.go
+++ b/internal/provider/models/destinations/new_relic.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type NewRelicDestinationModel struct {

--- a/internal/provider/models/destinations/prometheus_remote_write.go
+++ b/internal/provider/models/destinations/prometheus_remote_write.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type PrometheusRemoteWriteDestinationModel struct {

--- a/internal/provider/models/destinations/s3.go
+++ b/internal/provider/models/destinations/s3.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type S3DestinationModel struct {

--- a/internal/provider/models/destinations/splunk_hec_logs.go
+++ b/internal/provider/models/destinations/splunk_hec_logs.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type SplunkHecLogsDestinationModel struct {

--- a/internal/provider/models/destinations/test/azure_blob_storage_test.go
+++ b/internal/provider/models/destinations/test/azure_blob_storage_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestAzureBlobStorageDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/blackhole_test.go
+++ b/internal/provider/models/destinations/test/blackhole_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestBlackholeDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/datadog_logs_test.go
+++ b/internal/provider/models/destinations/test/datadog_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestDatadogLogsDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/datadog_metrics_test.go
+++ b/internal/provider/models/destinations/test/datadog_metrics_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestDatadogMetricsDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/elasticsearch_test.go
+++ b/internal/provider/models/destinations/test/elasticsearch_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestElasticSearchDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestGcpCloudStorageSinkResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/honeycomb_logs_test.go
+++ b/internal/provider/models/destinations/test/honeycomb_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestHoneycombLogsDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/http_test.go
+++ b/internal/provider/models/destinations/test/http_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestHttpDestination(t *testing.T) {

--- a/internal/provider/models/destinations/test/kafka_test.go
+++ b/internal/provider/models/destinations/test/kafka_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestKafkaDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/loki_test.go
+++ b/internal/provider/models/destinations/test/loki_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestLokiDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/mezmo_test.go
+++ b/internal/provider/models/destinations/test/mezmo_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestMezmoDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/new_relic_test.go
+++ b/internal/provider/models/destinations/test/new_relic_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestNewRelicDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/destinations/test/prometheus_remote_write_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestPrometheusDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/provider_test_factory.go
+++ b/internal/provider/models/destinations/test/provider_test_factory.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/destinations/test/s3_test.go
+++ b/internal/provider/models/destinations/test/s3_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestS3DestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/splunk_hec_logs_test.go
+++ b/internal/provider/models/destinations/test/splunk_hec_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestSplunkHecLogsDestinationResource(t *testing.T) {

--- a/internal/provider/models/pipeline.go
+++ b/internal/provider/models/pipeline.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type PipelineResourceModel struct {

--- a/internal/provider/models/processors/base_parse_model.go
+++ b/internal/provider/models/processors/base_parse_model.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 var base_options_parser_schema = SchemaAttributes{

--- a/internal/provider/models/processors/compact_fields.go
+++ b/internal/provider/models/processors/compact_fields.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type CompactFieldsProcessorModel struct {

--- a/internal/provider/models/processors/decrypt_fields.go
+++ b/internal/provider/models/processors/decrypt_fields.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type DecryptFieldsProcessorModel struct {

--- a/internal/provider/models/processors/dedupe.go
+++ b/internal/provider/models/processors/dedupe.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type DedupeProcessorModel struct {

--- a/internal/provider/models/processors/drop_fields.go
+++ b/internal/provider/models/processors/drop_fields.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type DropFieldsProcessorModel struct {

--- a/internal/provider/models/processors/encrypt_fields.go
+++ b/internal/provider/models/processors/encrypt_fields.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type EncryptFieldsProcessorModel struct {

--- a/internal/provider/models/processors/flatten_fields.go
+++ b/internal/provider/models/processors/flatten_fields.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type FlattenFieldsProcessorModel struct {

--- a/internal/provider/models/processors/parse.go
+++ b/internal/provider/models/processors/parse.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 	"golang.org/x/exp/slices"
 )
 

--- a/internal/provider/models/processors/parse_sequentially.go
+++ b/internal/provider/models/processors/parse_sequentially.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 	"golang.org/x/exp/slices"
 )
 

--- a/internal/provider/models/processors/reduce.go
+++ b/internal/provider/models/processors/reduce.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type ReduceProcessorModel struct {

--- a/internal/provider/models/processors/route.go
+++ b/internal/provider/models/processors/route.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type RouteProcessorModel struct {

--- a/internal/provider/models/processors/sample.go
+++ b/internal/provider/models/processors/sample.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type SampleProcessorModel struct {

--- a/internal/provider/models/processors/script_execution.go
+++ b/internal/provider/models/processors/script_execution.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type ScriptExecutionProcessorModel struct {

--- a/internal/provider/models/processors/stringify.go
+++ b/internal/provider/models/processors/stringify.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type StringifyProcessorModel struct {

--- a/internal/provider/models/processors/test/compact_fields_test.go
+++ b/internal/provider/models/processors/test/compact_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestCompactFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/decrypt_fields_test.go
+++ b/internal/provider/models/processors/test/decrypt_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestDecryptFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/dedupe_test.go
+++ b/internal/provider/models/processors/test/dedupe_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestDedupeProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/drop_fields_test.go
+++ b/internal/provider/models/processors/test/drop_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestDropFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/encrypt_fields_test.go
+++ b/internal/provider/models/processors/test/encrypt_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestEncryptFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/flatten_fields_test.go
+++ b/internal/provider/models/processors/test/flatten_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestFlattenFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/parse_sequentially_test.go
+++ b/internal/provider/models/processors/test/parse_sequentially_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestParseSequentiallyProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/parse_test.go
+++ b/internal/provider/models/processors/test/parse_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestParseProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/provider_test_factory.go
+++ b/internal/provider/models/processors/test/provider_test_factory.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/processors/test/reduce_test.go
+++ b/internal/provider/models/processors/test/reduce_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestReduceProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/route_test.go
+++ b/internal/provider/models/processors/test/route_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestRouteProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/sample_test.go
+++ b/internal/provider/models/processors/test/sample_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestSampleProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/script_execution_test.go
+++ b/internal/provider/models/processors/test/script_execution_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestScriptExecutionProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/stringify_test.go
+++ b/internal/provider/models/processors/test/stringify_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestStringifyProcessorResource(t *testing.T) {

--- a/internal/provider/models/processors/test/unroll_test.go
+++ b/internal/provider/models/processors/test/unroll_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestUnrollProcessor(t *testing.T) {

--- a/internal/provider/models/processors/unroll.go
+++ b/internal/provider/models/processors/unroll.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type UnrollProcessorModel struct {

--- a/internal/provider/models/sources/agent.go
+++ b/internal/provider/models/sources/agent.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type AgentSourceModel struct {

--- a/internal/provider/models/sources/azure_event_hub.go
+++ b/internal/provider/models/sources/azure_event_hub.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type AzureEventHubSourceModel struct {

--- a/internal/provider/models/sources/demo.go
+++ b/internal/provider/models/sources/demo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type DemoSourceModel struct {

--- a/internal/provider/models/sources/fluent.go
+++ b/internal/provider/models/sources/fluent.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type FluentSourceModel struct {

--- a/internal/provider/models/sources/http.go
+++ b/internal/provider/models/sources/http.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type HttpSourceModel struct {

--- a/internal/provider/models/sources/kafka.go
+++ b/internal/provider/models/sources/kafka.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type KafkaSourceModel struct {

--- a/internal/provider/models/sources/kinesis_firehose.go
+++ b/internal/provider/models/sources/kinesis_firehose.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type KinesisFirehoseSourceModel struct {

--- a/internal/provider/models/sources/log-analysis.go
+++ b/internal/provider/models/sources/log-analysis.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type LogAnalysisSourceModel struct {

--- a/internal/provider/models/sources/logstash.go
+++ b/internal/provider/models/sources/logstash.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type LogStashSourceModel struct {

--- a/internal/provider/models/sources/open_telemetry_traces.go
+++ b/internal/provider/models/sources/open_telemetry_traces.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type OpenTelemetryTracesSourceModel struct {

--- a/internal/provider/models/sources/prometheus_remote_write.go
+++ b/internal/provider/models/sources/prometheus_remote_write.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type PrometheusRemoteWriteSourceModel struct {

--- a/internal/provider/models/sources/s3.go
+++ b/internal/provider/models/sources/s3.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type S3SourceModel struct {

--- a/internal/provider/models/sources/splunk-hec.go
+++ b/internal/provider/models/sources/splunk-hec.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 type SplunkHecSourceModel struct {

--- a/internal/provider/models/sources/sqs.go
+++ b/internal/provider/models/sources/sqs.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 type SQSSourceModel struct {

--- a/internal/provider/models/sources/test/agent_test.go
+++ b/internal/provider/models/sources/test/agent_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestAgentSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/azure_event_hub_test.go
+++ b/internal/provider/models/sources/test/azure_event_hub_test.go
@@ -2,7 +2,7 @@ package sources
 
 import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 	"regexp"
 	"testing"
 )

--- a/internal/provider/models/sources/test/demo_test.go
+++ b/internal/provider/models/sources/test/demo_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestDemoSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/fluent_test.go
+++ b/internal/provider/models/sources/test/fluent_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestFluentSource(t *testing.T) {

--- a/internal/provider/models/sources/test/http_test.go
+++ b/internal/provider/models/sources/test/http_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestHttpSource(t *testing.T) {

--- a/internal/provider/models/sources/test/kafka_test.go
+++ b/internal/provider/models/sources/test/kafka_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestKafkaSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/kinesis_firehose_test.go
+++ b/internal/provider/models/sources/test/kinesis_firehose_test.go
@@ -2,7 +2,7 @@ package sources
 
 import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 	"regexp"
 	"testing"
 )

--- a/internal/provider/models/sources/test/log_analysis_test.go
+++ b/internal/provider/models/sources/test/log_analysis_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestLogAnalysisSource(t *testing.T) {

--- a/internal/provider/models/sources/test/logstash_test.go
+++ b/internal/provider/models/sources/test/logstash_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestLogStashSource(t *testing.T) {

--- a/internal/provider/models/sources/test/open_telemetry_traces_test.go
+++ b/internal/provider/models/sources/test/open_telemetry_traces_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestOpenTelemetryTracesSource(t *testing.T) {

--- a/internal/provider/models/sources/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/sources/test/prometheus_remote_write_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestPrometheusRemoteWriteSource(t *testing.T) {

--- a/internal/provider/models/sources/test/provider_test_factory.go
+++ b/internal/provider/models/sources/test/provider_test_factory.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/sources/test/s3_test.go
+++ b/internal/provider/models/sources/test/s3_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestS3SourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/splunk_hec_test.go
+++ b/internal/provider/models/sources/test/splunk_hec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestSplunkHecSource(t *testing.T) {

--- a/internal/provider/models/sources/test/sqs_test.go
+++ b/internal/provider/models/sources/test/sqs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestSQSSource(t *testing.T) {

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models"
+	"github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models"
 )
 
 var (

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
 )
 
 func TestPipelineResource(t *testing.T) {

--- a/internal/provider/processor_resource.go
+++ b/internal/provider/processor_resource.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/processors"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/processors"
 )
 
 type ProcessorModel interface {

--- a/internal/provider/processor_resource_definitions.go
+++ b/internal/provider/processor_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/processors"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/processors"
 )
 
 func NewDedupeProcessorResource() resource.Resource {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 var _ provider.Provider = &MezmoProvider{}

--- a/internal/provider/providertest/utils.go
+++ b/internal/provider/providertest/utils.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
 const authAccountId = "tf_test_01"

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/modelutils"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/sources"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/sources"
 )
 
 type SourceModel interface {

--- a/internal/provider/source_resource_definitions.go
+++ b/internal/provider/source_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/provider/models/sources"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/sources"
 )
 
 func NewDemoSourceResource() resource.Resource {

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
 // Generic type representing a source / processor / destination model.

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
 )
 
 // Note that Terraform Provider Framework expects a binary called `terraform-provider-{name-of-the-provider}`

--- a/pkg/resources/convertible.go
+++ b/pkg/resources/convertible.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
 	"reflect"
 )
 

--- a/pkg/resources/convertible_test.go
+++ b/pkg/resources/convertible_test.go
@@ -2,7 +2,7 @@ package resources
 
 import (
 	"context"
-	"github.com/mezmo-inc/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
The code in the repo was developed before we secured the `mezmo` GitHub org and so all of the modules referred to `mezmo-inc` in their path. This commit updates them to the desired org we want to use.

Ref: LOG-18273