### PR TITLE
feat: Make convertible resource typenames unique

### DIFF
--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"os"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
@@ -43,7 +44,7 @@ type DestinationResource[T DestinationModel] struct {
 }
 
 func (r *DestinationResource[T]) TypeName() string {
-	return r.typeName
+	return r.typeName + "_destination"
 }
 
 func (r *DestinationResource[T]) TerraformSchema() schema.Schema {
@@ -145,7 +146,7 @@ func (r *DestinationResource[T]) Delete(ctx context.Context, req resource.Delete
 
 // Metadata implements resource.Resource.
 func (r *DestinationResource[T]) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_" + r.typeName + "_destination"
+	resp.TypeName = req.ProviderTypeName + "_" + r.TypeName()
 }
 
 // Read implements resource.Resource.

--- a/internal/provider/processor_resource.go
+++ b/internal/provider/processor_resource.go
@@ -44,7 +44,7 @@ type ProcessorResource[T ProcessorModel] struct {
 }
 
 func (r *ProcessorResource[T]) TypeName() string {
-	return r.typeName
+	return r.typeName + "_processor"
 }
 
 func (r *ProcessorResource[T]) TerraformSchema() schema.Schema {
@@ -146,7 +146,7 @@ func (r *ProcessorResource[T]) Delete(ctx context.Context, req resource.DeleteRe
 
 // Metadata implements resource.Resource.
 func (r *ProcessorResource[T]) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_" + r.typeName + "_processor"
+	resp.TypeName = req.ProviderTypeName + "_" + r.TypeName()
 }
 
 // Read implements resource.Resource.

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"os"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
@@ -41,7 +42,7 @@ type SourceResource[T SourceModel] struct {
 }
 
 func (r *SourceResource[T]) TypeName() string {
-	return r.typeName
+	return r.typeName + "_source"
 }
 
 func (r *SourceResource[T]) TerraformSchema() schema.Schema {
@@ -143,7 +144,7 @@ func (r *SourceResource[T]) Delete(ctx context.Context, req resource.DeleteReque
 
 // Metadata implements resource.Resource.
 func (r *SourceResource[T]) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_" + r.typeName + "_source"
+	resp.TypeName = req.ProviderTypeName + "_" + r.TypeName()
 }
 
 // Read implements resource.Resource.


### PR DESCRIPTION
The JSON api model returns `http` for both http source and http sink making it difficult to identify conflicting resources.
This PR fixes it