### PR TITLE
fix: Ensure processors can be converted to terraform model

### DIFF
--- a/examples/processors/parse_sequentially.tf
+++ b/examples/processors/parse_sequentially.tf
@@ -22,7 +22,7 @@ resource "mezmo_http_source" "curl" {
   decoding    = "json"
 }
 
-resource "mezmo_parse_processor" "processor1" {
+resource "mezmo_parse_sequentially_processor" "processor1" {
   pipeline_id  = mezmo_pipeline.pipeline1.id
   title        = "Apache parser"
   description  = "Parse logs"
@@ -53,7 +53,7 @@ resource "mezmo_logs_destination" "destination1" {
   pipeline_id   = mezmo_pipeline.pipeline1.id
   title         = "My destination"
   description   = "Send logs to Mezmo Log Analysis"
-  inputs        = [mezmo_route_processor.processor1.parsers.0.output_name]
+  inputs        = [mezmo_parse_sequentially_processor.processor1.parsers.0.output_name]
   ingestion_key = var.my_ingestion_key
 }
 
@@ -62,20 +62,12 @@ resource "mezmo_blackhole_destination" "destination2" {
   title        = "My destination"
   description  = "Trash the data without acking"
   acks_enabled = false
-  inputs       = [mezmo_route_processor.processor1.parsers.1.output_name]
-}
-
-resource "mezmo_blackhole_destination" "destination2" {
-  pipeline_id  = mezmo_pipeline.pipeline1.id
-  title        = "My destination"
-  description  = "Trash the data without acking"
-  acks_enabled = false
-  inputs       = [mezmo_route_processor.processor1.parsers.1.output_name]
+  inputs       = [mezmo_parse_sequentially_processor.processor1.parsers.1.output_name]
 }
 
 resource "mezmo_http_destination" "destination3" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Http desintation"
   description = "Send data to an HTTP destination"
-  inputs      = [mezmo_route_processor.processor1.parsers.2.output_name]
+  inputs      = [mezmo_parse_sequentially_processor.processor1.parsers.2.output_name]
 }

--- a/internal/provider/models/processors/parse_sequentially.go
+++ b/internal/provider/models/processors/parse_sequentially.go
@@ -167,9 +167,17 @@ func (plan *ParseSequentiallyProcessorModel) setParsers(api_parsers []map[string
 		parsers = append(parsers, parser_item)
 	}
 
-	if len(parsers) > 0 {
-		plan.Parsers = basetypes.NewListValueMust(plan.Parsers.ElementType(context.Background()), parsers)
+	if len(parsers) == 0 {
+		return
 	}
+	elemType := plan.Parsers.ElementType(context.Background())
+	// used by ConvertToTerraformModel method
+	// when hydrating without a terraform state, the list element type is nil
+	if elemType == nil {
+		listType := ParseSequentiallyProcessorResourceSchema.Attributes["parsers"].GetType()
+		elemType = listType.(basetypes.ListType).ElementType()
+	}
+	plan.Parsers = basetypes.NewListValueMust(elemType, parsers)
 }
 
 // convert parser entry in API response to map of Terraform values

--- a/internal/provider/models/processors/route.go
+++ b/internal/provider/models/processors/route.go
@@ -87,7 +87,15 @@ func RouteProcessorToModel(plan *RouteProcessorModel, component *Processor) {
 
 	conditionals, ok := component.UserConfig["conditionals"].([]any)
 	if ok {
-		list_value, diag := conditionalsToModel(conditionals, plan.Conditionals.ElementType(context.Background()))
+		elemType := plan.Conditionals.ElementType(context.Background())
+		if elemType == nil {
+			// used by ConvertToTerraformModel method
+			// when hydrating without a terraform state, the list element type is nil
+			listType := RouteProcessorResourceSchema.Attributes["conditionals"].GetType()
+			elemType = listType.(basetypes.ListType).ElementType()
+		}
+
+		list_value, diag := conditionalsToModel(conditionals, elemType)
 
 		if !diag.HasError() {
 			plan.Conditionals = list_value

--- a/pkg/resources/convertible.go
+++ b/pkg/resources/convertible.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 
@@ -31,7 +30,7 @@ func ConvertibleResources() ([]ConvertibleResourceDef, error) {
 		tfRes := tfResFn()
 		cRes, ok := tfRes.(ConvertibleResourceDef)
 		if !ok {
-			err := errors.New(fmt.Sprintf("terraform resource %T does not implement ConvertibleResourceDef", tfRes))
+			err := fmt.Errorf("terraform resource %T does not implement ConvertibleResourceDef", tfRes)
 			return nil, err
 		}
 		convertibleRes[i] = cRes

--- a/pkg/resources/convertible_test.go
+++ b/pkg/resources/convertible_test.go
@@ -2,10 +2,37 @@ package resources
 
 import (
 	"context"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/processors"
 )
+
+var (
+	_, b, _, _   = runtime.Caller(0)
+	basepath     = filepath.Dir(b)
+	testdataPath = path.Join(basepath, "testdata")
+)
+
+func loadJsonFile[T any](t *testing.T, filename string) *T {
+	t.Helper()
+	bytes, err := os.ReadFile(path.Join(testdataPath, filename))
+	if err != nil {
+		t.Fatalf("Could not read %s file. Reason: %s", filename, err)
+	}
+	var into T
+	if err := json.Unmarshal(bytes, &into); err != nil {
+		t.Fatalf("Could not encode %s to json. Reason: %s", filename, err)
+	}
+	return &into
+}
 
 func TestConvertibleResources(t *testing.T) {
 	var unmatchedResources = make(map[string]bool)
@@ -43,5 +70,589 @@ func TestConvertibleResources(t *testing.T) {
 				unmatchedType,
 			)
 		}
+	}
+}
+
+func findConvertibleResource(t *testing.T, resourceTypeName string) ConvertibleResourceDef {
+	t.Helper()
+	convResources, err := ConvertibleResources()
+	if err != nil {
+		t.Fatal("no convertible resources found")
+	}
+
+	for _, res := range convResources {
+		if res.TypeName() == resourceTypeName {
+			return res
+		}
+	}
+	t.Fatalf("resource %s not found", resourceTypeName)
+	return nil
+}
+
+func TestRouteResource(t *testing.T) {
+	type args struct {
+		resourceName string
+		model        *reflect.Value
+	}
+	tests := []struct {
+		name       string
+		args       args
+		assertions func(p *reflect.Value)
+	}{
+		{
+			name: "converts simple route processor to terraform model",
+			args: args{
+				resourceName: "route_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "simple_route.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.RouteProcessorModel)
+
+				var actualInputs []string
+				for _, item := range model.Inputs.Elements() {
+					v, _ := item.(basetypes.StringValue)
+					actualInputs = append(actualInputs, v.ValueString())
+				}
+				expectedInputs := []string{"12d94f50-6c68-11ee-bdee-6671faf7df66"}
+				if !reflect.DeepEqual(actualInputs, expectedInputs) {
+					t.Errorf("simple_route processor inputs do not match.\nexpected: %s\ngot: %s", expectedInputs, actualInputs)
+				}
+
+				if len(model.Conditionals.Elements()) == 0 {
+					t.Fatal("simple_route processor returned zero conditionals. wanted 1")
+				}
+
+				elem, _ := model.Conditionals.Elements()[0].(basetypes.ObjectValue)
+				label := elem.Attributes()["label"].(basetypes.StringValue).ValueString()
+				logicalOperation := elem.Attributes()["logical_operation"].(basetypes.StringValue).ValueString()
+				outputName := elem.Attributes()["output_name"].(basetypes.StringValue).ValueString()
+
+				if label != "Error logs" {
+					t.Errorf("simple_route processor label error. wanted: 'Error logs', got: '%s'", label)
+				}
+				if logicalOperation != "OR" {
+					t.Errorf("simple_route processor logical operation error. wanted: 'OR', got: '%s'", logicalOperation)
+				}
+				if outputName != "805821a7" {
+					t.Errorf("simple_route processor output name error. wanted: '805821a7', got: '%s'", outputName)
+				}
+			},
+		},
+		{
+			name: "converts route processor to terraform model",
+			args: args{
+				resourceName: "route_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "route.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.RouteProcessorModel)
+
+				var actualInputs []string
+				for _, item := range model.Inputs.Elements() {
+					v, _ := item.(basetypes.StringValue)
+					actualInputs = append(actualInputs, v.ValueString())
+				}
+				expectedInputs := []string{
+					"12d94f50-6c68-11ee-bdee-6671faf7df66",
+					"7b212506-23cb-11ed-b300-4ef12c27e273",
+				}
+				if !reflect.DeepEqual(actualInputs, expectedInputs) {
+					t.Errorf("route processor inputs do not match.\nexpected: %s\ngot: %s", expectedInputs, actualInputs)
+				}
+
+				if len(model.Conditionals.Elements()) == 0 {
+					t.Fatal("route processor returned zero conditionals. wanted 2")
+				}
+
+				expectedConditionals := []struct {
+					label            string
+					outputName       string
+					logicalOperation string
+				}{
+					{
+						label:            "Error logs",
+						outputName:       "805821a7",
+						logicalOperation: "OR",
+					},
+					{
+						label:            "App info logs",
+						outputName:       "c6b6ebe5",
+						logicalOperation: "AND",
+					},
+				}
+				for i, v := range model.Conditionals.Elements() {
+					elem, _ := v.(basetypes.ObjectValue)
+					label := elem.Attributes()["label"].(basetypes.StringValue).ValueString()
+					logicalOperation := elem.Attributes()["logical_operation"].(basetypes.StringValue).ValueString()
+					outputName := elem.Attributes()["output_name"].(basetypes.StringValue).ValueString()
+
+					if label != expectedConditionals[i].label {
+						t.Errorf("route processor label error. wanted: '%s', got: '%s'", expectedConditionals[i].label, label)
+					}
+					if logicalOperation != expectedConditionals[i].logicalOperation {
+						t.Errorf("route processor logical operation error. wanted: '%s', got: '%s'", expectedConditionals[i].logicalOperation, logicalOperation)
+					}
+					if outputName != expectedConditionals[i].outputName {
+						t.Errorf("route processor logical operation error. wanted: '%s', got: '%s'", expectedConditionals[i].logicalOperation, logicalOperation)
+					}
+				}
+			},
+		},
+		{
+			name: "converts parse sequentially processor to terraform model",
+			args: args{
+				resourceName: "parse_sequentially_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "parse_sequentially.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.ParseSequentiallyProcessorModel)
+
+				var actualInputs []string
+				for _, item := range model.Inputs.Elements() {
+					v, _ := item.(basetypes.StringValue)
+					actualInputs = append(actualInputs, v.ValueString())
+				}
+				expectedInputs := []string{
+					"110ec7da-5c7e-11ee-bffb-26dab184329f",
+				}
+				if !reflect.DeepEqual(actualInputs, expectedInputs) {
+					t.Errorf("parse sequentially inputs do not match.\nexpected: %s\ngot: %s", expectedInputs, actualInputs)
+				}
+
+				if len(model.Parsers.Elements()) == 0 {
+					t.Fatal("parse sequentially returned zero parsers. wanted 2")
+				}
+
+				expectedParsers := []struct {
+					label      string
+					parser     string
+					outputName string
+				}{
+					{
+						label:      "Apache Error",
+						outputName: "36d9714483c9745012cd14f9380335ac",
+						// converts from parse_apache_log to apache_log
+						parser: "apache_log",
+					},
+					{
+						label:      "Nginx Combined",
+						outputName: "5db52e644356529da4e34663969833b9",
+						// converts from parse_nginx_log to nginx_log
+						parser: "nginx_log",
+					},
+				}
+				for i, v := range model.Parsers.Elements() {
+					elem, _ := v.(basetypes.ObjectValue)
+					label := elem.Attributes()["label"].(basetypes.StringValue).ValueString()
+					parser := elem.Attributes()["parser"].(basetypes.StringValue).ValueString()
+					outputName := elem.Attributes()["output_name"].(basetypes.StringValue).ValueString()
+
+					if label != expectedParsers[i].label {
+						t.Errorf("parse sequentially label error. wanted: '%s', got: '%s'", expectedParsers[i].label, label)
+					}
+					if parser != expectedParsers[i].parser {
+						t.Errorf("parse sequentially parser error. wanted: '%s', got: '%s'", expectedParsers[i].parser, parser)
+					}
+					if outputName != expectedParsers[i].outputName {
+						t.Errorf("parse sequentially output name error. wanted: '%s', got: '%s'", expectedParsers[i].outputName, outputName)
+					}
+				}
+			},
+		},
+		{
+			name: "converts dedupe processor to terraform model",
+			args: args{
+				resourceName: "dedupe_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "dedupe.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.DedupeProcessorModel)
+
+				expected := struct {
+					numEvents      int64
+					comparisonType string
+					inputs         []string
+					fields         []string
+				}{
+					numEvents:      5000,
+					comparisonType: "Match",
+					inputs:         []string{"7b212506-23cb-11ed-b300-4ef12c27e273"},
+					fields:         []string{".foo", ".bar"},
+				}
+
+				numEvents := model.NumberOfEvents.ValueInt64()
+				if numEvents != expected.numEvents {
+					t.Errorf("dedupe number of events don't match. wanted: %v, got: %v", expected.numEvents, numEvents)
+				}
+				compType := model.ComparisonType.ValueString()
+				if compType != expected.comparisonType {
+					t.Errorf("dedupe comparison types don't match. wanted: %s, got: %s", expected.comparisonType, compType)
+				}
+				var fields []string
+				for _, item := range model.Fields.Elements() {
+					fields = append(fields, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(fields, expected.fields) {
+					t.Errorf("dedupe fields don't match. wanted: %s, got: %s", expected.fields, fields)
+				}
+				var inputs []string
+				for _, item := range model.Inputs.Elements() {
+					inputs = append(inputs, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(inputs, expected.inputs) {
+					t.Errorf("dedupe inputs don't match. wanted: %s, got: %s", expected.inputs, inputs)
+				}
+			},
+		},
+		{
+			name: "converts drop fields processor to terraform model",
+			args: args{
+				resourceName: "drop_fields_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "drop_fields.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.DropFieldsProcessorModel)
+
+				expected := struct {
+					inputs []string
+					fields []string
+				}{
+					inputs: []string{"7b212506-23cb-11ed-b300-4ef12c27e273"},
+					fields: []string{".errors", ".warnings"},
+				}
+
+				var fields []string
+				for _, item := range model.Fields.Elements() {
+					fields = append(fields, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(fields, expected.fields) {
+					t.Errorf("drop processor fields don't match. wanted: %s, got: %s", expected.fields, fields)
+				}
+				var inputs []string
+				for _, item := range model.Inputs.Elements() {
+					inputs = append(inputs, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(inputs, expected.inputs) {
+					t.Errorf("drop processor inputs don't match. wanted: %s, got: %s", expected.inputs, inputs)
+				}
+			},
+		},
+		{
+			name: "converts flatten fields processor to terraform model",
+			args: args{
+				resourceName: "flatten_fields_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "flatten_fields.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.FlattenFieldsProcessorModel)
+
+				expected := struct {
+					inputs    []string
+					fields    []string
+					delimiter string
+				}{
+					inputs:    []string{"7b212506-23cb-11ed-b300-4ef12c27e273"},
+					fields:    []string{".list", ".map"},
+					delimiter: ",",
+				}
+
+				delimiter := model.Delimiter.ValueString()
+				if delimiter != expected.delimiter {
+					t.Errorf("flatten fields delimiters don't match. wanted: %s, got: %s", expected.delimiter, delimiter)
+				}
+
+				var fields []string
+				for _, item := range model.Fields.Elements() {
+					fields = append(fields, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(fields, expected.fields) {
+					t.Errorf("flatten fields processor fields don't match. wanted: %s, got: %s", expected.fields, fields)
+				}
+				var inputs []string
+				for _, item := range model.Inputs.Elements() {
+					inputs = append(inputs, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(inputs, expected.inputs) {
+					t.Errorf("flatten fields processor inputs don't match. wanted: %s, got: %s", expected.inputs, inputs)
+				}
+			},
+		},
+		{
+			name: "converts map fields processor to terraform model",
+			args: args{
+				resourceName: "map_fields_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "map_fields.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.MapFieldsProcessorModel)
+
+				type mapping struct {
+					target          string
+					source          string
+					dropSource      bool
+					overwriteTarget bool
+				}
+				expected := struct {
+					inputs   []string
+					mappings []mapping
+				}{
+					inputs: []string{"7b212506-23cb-11ed-b300-4ef12c27e273"},
+					mappings: []mapping{
+						{
+							dropSource:      true,
+							source:          ".firstname",
+							target:          ".fname",
+							overwriteTarget: false,
+						},
+						{
+							dropSource:      true,
+							source:          ".lastname",
+							target:          ".lname",
+							overwriteTarget: true,
+						},
+					},
+				}
+
+				var inputs []string
+				for _, item := range model.Inputs.Elements() {
+					inputs = append(inputs, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(inputs, expected.inputs) {
+					t.Errorf("map fields processor inputs don't match. wanted: %s, got: %s", expected.inputs, inputs)
+				}
+
+				for i, item := range model.Mappings.Elements() {
+					v := item.(basetypes.ObjectValue)
+					source := v.Attributes()["source_field"].(basetypes.StringValue).ValueString()
+					target := v.Attributes()["target_field"].(basetypes.StringValue).ValueString()
+					dropSource := v.Attributes()["drop_source"].(basetypes.BoolValue).ValueBool()
+					overwriteTarget := v.Attributes()["overwrite_target"].(basetypes.BoolValue).ValueBool()
+
+					if source != expected.mappings[i].source {
+						t.Errorf("map fields sources don't match. wanted: %s, got: %s", expected.mappings[i].source, source)
+					}
+					if target != expected.mappings[i].target {
+						t.Errorf("map fields targets don't match. wanted: %s, got: %s", expected.mappings[i].target, target)
+					}
+					if dropSource != expected.mappings[i].dropSource {
+						t.Errorf("map fields drop sources don't match. wanted: %v, got: %v", expected.mappings[i].dropSource, dropSource)
+					}
+					if overwriteTarget != expected.mappings[i].overwriteTarget {
+						t.Errorf("map fields overwrite targets don't match. wanted: %v, got: %v", expected.mappings[i].overwriteTarget, overwriteTarget)
+					}
+				}
+			},
+		},
+		{
+			name: "converts parse processor to terraform model",
+			args: args{
+				resourceName: "parse_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "parse.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.ParseProcessorModel)
+
+				expected := struct {
+					inputs  []string
+					field   string
+					target  string
+					parser  string
+					options map[string]string
+				}{
+					inputs: []string{"7b212506-23cb-11ed-b300-4ef12c27e273"},
+					field:  ".",
+					target: ".parsed",
+					parser: "nginx_log",
+					options: map[string]string{
+						"format":           "error",
+						"timestamp_format": "%Y-%m-%dT%H:%M:%SZ",
+					},
+				}
+
+				var inputs []string
+				for _, item := range model.Inputs.Elements() {
+					inputs = append(inputs, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(inputs, expected.inputs) {
+					t.Errorf("parse processor inputs don't match. wanted: %s, got: %s", expected.inputs, inputs)
+				}
+
+				if model.Field.ValueString() != expected.field {
+					t.Errorf("parse processor fields don't match. wanted: %s, got: %s", expected.field, model.Field.ValueString())
+				}
+				if model.TargetField.ValueString() != expected.target {
+					t.Errorf("parse processor target fields don't match. wanted: %s, got: %s", expected.target, model.TargetField.ValueString())
+				}
+				format := model.NginxOptions.Attributes()["format"].(basetypes.StringValue).ValueString()
+				timeFormat := model.NginxOptions.Attributes()["timestamp_format"].(basetypes.StringValue).ValueString()
+
+				if format != expected.options["format"] {
+					t.Errorf("parse processor format options don't match. wanted: %s, got: %s", expected.options["format"], format)
+				}
+				if timeFormat != expected.options["timestamp_format"] {
+					t.Errorf("parse processor timestamp format options don't match. wanted: %s, got: %s", expected.options["timestamp_format"], timeFormat)
+				}
+			},
+		},
+		{
+			name: "converts reduce processor to terraform model",
+			args: args{
+				resourceName: "reduce_processor",
+				model: func() *reflect.Value {
+					t.Helper()
+					model := loadJsonFile[ProcessorApiModel](t, "reduce.json")
+					rModel := reflect.ValueOf(*model)
+					return &rModel
+				}(),
+			},
+			assertions: func(p *reflect.Value) {
+				model := p.Interface().(processors.ReduceProcessorModel)
+
+				type dateFormat struct {
+					field  string
+					format string
+				}
+				type mergeStrategy struct {
+					field    string
+					strategy string
+				}
+				expected := struct {
+					inputs          []string
+					groupBy         []string
+					dateFormats     []dateFormat
+					mergeStrategies []mergeStrategy
+				}{
+					inputs: []string{"7b212506-23cb-11ed-b300-4ef12c27e273"},
+					groupBy: []string{
+						".error.level",
+						".user.email",
+					},
+					dateFormats: []dateFormat{
+						{
+							field:  ".log_date",
+							format: "%Y-%m-%dT%H:%M:%S",
+						},
+					},
+					mergeStrategies: []mergeStrategy{
+						{
+							field:    ".errors",
+							strategy: "flat_unique",
+						},
+						{
+							field:    ".users",
+							strategy: "concat_raw",
+						},
+					},
+				}
+
+				var inputs []string
+				for _, item := range model.Inputs.Elements() {
+					inputs = append(inputs, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(inputs, expected.inputs) {
+					t.Errorf("reduce processor inputs don't match. wanted: %s, got: %s", expected.inputs, inputs)
+				}
+
+				var dateFormats []dateFormat
+				for _, item := range model.DateFormats.Elements() {
+					v := item.(basetypes.ObjectValue)
+					dateFormats = append(dateFormats, dateFormat{
+						field:  v.Attributes()["field"].(basetypes.StringValue).ValueString(),
+						format: v.Attributes()["format"].(basetypes.StringValue).ValueString(),
+					})
+				}
+				if !reflect.DeepEqual(dateFormats, expected.dateFormats) {
+					t.Errorf("reduce processor date formats don't match. wanted: %s, got: %s", expected.dateFormats, dateFormats)
+				}
+
+				var mergeStrategies []mergeStrategy
+				for _, item := range model.MergeStrategies.Elements() {
+					v := item.(basetypes.ObjectValue)
+					mergeStrategies = append(mergeStrategies, mergeStrategy{
+						field:    v.Attributes()["field"].(basetypes.StringValue).ValueString(),
+						strategy: v.Attributes()["strategy"].(basetypes.StringValue).ValueString(),
+					})
+				}
+				if !reflect.DeepEqual(mergeStrategies, expected.mergeStrategies) {
+					t.Errorf("reduce processor date formats don't match. wanted: %s, got: %s", expected.mergeStrategies, mergeStrategies)
+				}
+
+				var groupBy []string
+				for _, item := range model.GroupBy.Elements() {
+					groupBy = append(groupBy, item.(basetypes.StringValue).ValueString())
+				}
+				if !reflect.DeepEqual(groupBy, expected.groupBy) {
+					t.Errorf("reduce processor group bys don't match. wanted: %s, got: %s", expected.groupBy, groupBy)
+				}
+
+				conditions := model.FlushCondition.Attributes()
+				flushWhen := conditions["when"].(basetypes.StringValue).ValueString()
+				if flushWhen != "starts_when" {
+					t.Errorf("reduce processor flush whens don't match. wanted: starts_when, got: %s", flushWhen)
+				}
+				// 2 expressions and 1 nested expression
+				expressions := conditions["conditional"].(basetypes.ObjectValue).Attributes()["expressions"].(basetypes.ListValue)
+				expressionGroups := conditions["conditional"].(basetypes.ObjectValue).Attributes()["expressions_group"].(basetypes.ListValue)
+
+				if len(expressionGroups.Elements()) != 1 {
+					t.Errorf("reduce processor returned %v nested expressions. wanted: 1", len(expressionGroups.Elements()))
+				}
+				if len(expressions.Elements()) != 2 {
+					t.Errorf("reduce processor returned %v expressions. wanted: 2", len(expressions.Elements()))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := findConvertibleResource(t, tt.args.resourceName)
+			m, err := res.ConvertToTerraformModel(tt.args.model)
+
+			if err != nil {
+				t.Fatalf("could not convert %s to terraform model. reason: %s", tt.args.resourceName, err)
+			}
+			tt.assertions(m)
+		})
 	}
 }

--- a/pkg/resources/testdata/compact_fields.json
+++ b/pkg/resources/testdata/compact_fields.json
@@ -1,0 +1,29 @@
+{
+  "id": "79551faa-6c6a-11ee-be81-6671faf7df66",
+  "title": "compact fields processor title",
+  "description": "compact fields processor description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 1,
+  "type": "compact-fields",
+  "deploy_type": "saas",
+  "user_config": {
+    "fields": [
+      ".raw",
+      ".options"
+    ],
+    "options": {
+      "compact_array": true,
+      "compact_object": true
+    }
+  },
+  "inputs": [
+    "563d2374-63ae-11ee-abe2-26dab184329f.805821a7"
+  ],
+  "outputs": [
+    {
+      "id": "79551faa-6c6a-11ee-be81-6671faf7df66",
+      "label": "Default"
+    }
+  ]
+}

--- a/pkg/resources/testdata/dedupe.json
+++ b/pkg/resources/testdata/dedupe.json
@@ -1,0 +1,25 @@
+{
+  "id": "4b3de882-6e2b-11ee-98fa-6671faf7df66",
+  "title": "dedupe title",
+  "description": "dedupe description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 0,
+  "type": "dedupe",
+  "deploy_type": "saas",
+  "user_config": {
+      "fields": [
+          ".foo",
+          ".bar"
+      ],
+      "comparison_type": "Match",
+      "number_of_events": 5000
+  },
+  "inputs": ["7b212506-23cb-11ed-b300-4ef12c27e273"],
+  "outputs": [
+      {
+          "id": "4b3de882-6e2b-11ee-98fa-6671faf7df66",
+          "label": "Default"
+      }
+  ]
+}

--- a/pkg/resources/testdata/drop_fields.json
+++ b/pkg/resources/testdata/drop_fields.json
@@ -1,0 +1,23 @@
+{
+  "id": "b1a1f3e8-6e2b-11ee-9268-6671faf7df66",
+  "title": "remove title",
+  "description": "remove description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 1,
+  "type": "drop-fields",
+  "deploy_type": "saas",
+  "user_config": {
+      "fields": [
+          ".errors",
+          ".warnings"
+      ]
+  },
+  "inputs": ["7b212506-23cb-11ed-b300-4ef12c27e273"],
+  "outputs": [
+      {
+          "id": "b1a1f3e8-6e2b-11ee-9268-6671faf7df66",
+          "label": "Default"
+      }
+  ]
+}

--- a/pkg/resources/testdata/flatten_fields.json
+++ b/pkg/resources/testdata/flatten_fields.json
@@ -1,0 +1,26 @@
+{
+  "id": "6f26af30-6e2c-11ee-bed9-6671faf7df66",
+  "title": "flatten title",
+  "description": "flatten description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 0,
+  "type": "flatten-fields",
+  "deploy_type": "saas",
+  "user_config": {
+      "fields": [
+          ".list",
+          ".map"
+      ],
+      "options": {
+          "delimiter": ","
+      }
+  },
+  "inputs": ["7b212506-23cb-11ed-b300-4ef12c27e273"],
+  "outputs": [
+      {
+          "id": "6f26af30-6e2c-11ee-bed9-6671faf7df66",
+          "label": "Default"
+      }
+  ]
+}

--- a/pkg/resources/testdata/map_fields.json
+++ b/pkg/resources/testdata/map_fields.json
@@ -1,0 +1,33 @@
+{
+  "id": "9d4b677a-6e2c-11ee-a476-6671faf7df66",
+  "title": "map title",
+  "description": "map description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 0,
+  "type": "map-fields",
+  "deploy_type": "saas",
+  "user_config": {
+      "mappings": [
+          {
+              "drop_source": true,
+              "source_field": ".firstname",
+              "target_field": ".fname",
+              "overwrite_target": false
+          },
+          {
+              "drop_source": true,
+              "source_field": ".lastname",
+              "target_field": ".lname",
+              "overwrite_target": true
+          }
+      ]
+  },
+  "inputs": ["7b212506-23cb-11ed-b300-4ef12c27e273"],
+  "outputs": [
+      {
+          "id": "9d4b677a-6e2c-11ee-a476-6671faf7df66",
+          "label": "Default"
+      }
+  ]
+}

--- a/pkg/resources/testdata/parse.json
+++ b/pkg/resources/testdata/parse.json
@@ -1,0 +1,26 @@
+{
+  "id": "ccceff16-6e2c-11ee-80ec-6671faf7df66",
+  "title": "parse title",
+  "description": "parse description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 0,
+  "type": "parse",
+  "deploy_type": "saas",
+  "user_config": {
+      "field": ".",
+      "parser": "parse_nginx_log",
+      "options": {
+          "format": "error",
+          "timestamp_format": "%Y-%m-%dT%H:%M:%SZ"
+      },
+      "target_field": ".parsed"
+  },
+  "inputs": ["7b212506-23cb-11ed-b300-4ef12c27e273"],
+  "outputs": [
+      {
+          "id": "ccceff16-6e2c-11ee-80ec-6671faf7df66",
+          "label": "Default"
+      }
+  ]
+}

--- a/pkg/resources/testdata/parse_sequentially.json
+++ b/pkg/resources/testdata/parse_sequentially.json
@@ -1,0 +1,51 @@
+{
+  "id": "9040df3a-63ad-11ee-956d-26dab184329f",
+  "title": "parse sequentially processor title",
+  "description": "parse sequentially processor description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 3,
+  "type": "parse-sequentially",
+  "deploy_type": "saas",
+  "user_config": {
+    "field": ".",
+    "parsers": [
+      {
+        "label": "Apache Error",
+        "parser": "parse_apache_log",
+        "options": {
+          "format": "error",
+          "timestamp_format": "%d/%b/%Y:%T %z"
+        },
+        "_output_name": "36d9714483c9745012cd14f9380335ac"
+      },
+      {
+        "label": "Nginx Combined",
+        "parser": "parse_nginx_log",
+        "options": {
+          "format": "combined",
+          "timestamp_format": "%d/%b/%Y:%T %z"
+        },
+        "_output_name": "5db52e644356529da4e34663969833b9"
+      }
+    ],
+    "target_field": ""
+  },
+  "inputs": [
+    "110ec7da-5c7e-11ee-bffb-26dab184329f"
+  ],
+  "outputs": [
+    {
+      "id": "9040df3a-63ad-11ee-956d-26dab184329f._unmatched",
+      "label": "Unmatched"
+    },
+    {
+      "id": "9040df3a-63ad-11ee-956d-26dab184329f.36d9714483c9745012cd14f9380335ac",
+      "label": "Apache Error"
+    },
+    {
+      "id": "9040df3a-63ad-11ee-956d-26dab184329f.5db52e644356529da4e34663969833b9",
+      "label": "Nginx Combined"
+    }
+  ]
+}

--- a/pkg/resources/testdata/reduce.json
+++ b/pkg/resources/testdata/reduce.json
@@ -1,0 +1,73 @@
+{
+  "id": "857b5780-6e2d-11ee-b813-6671faf7df66",
+  "title": "reduce title",
+  "description": "reduce description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 1,
+  "type": "reduce",
+  "deploy_type": "saas",
+  "user_config": {
+      "group_by": [
+          ".error.level",
+          ".user.email"
+      ],
+      "duration_ms": 30000,
+      "date_formats": [
+          {
+              "field": ".log_date",
+              "format": "%Y-%m-%dT%H:%M:%S"
+          }
+      ],
+      "flush_condition": {
+          "when": "starts_when",
+          "conditional": {
+              "expressions": [
+                  {
+                      "field": ".level",
+                      "value": "299",
+                      "str_operator": "greater"
+                  },
+                  {
+                      "field": ".app",
+                      "value": "main",
+                      "str_operator": "contains"
+                  },
+                  {
+                      "expressions": [
+                          {
+                              "field": ".host",
+                              "value": "https",
+                              "str_operator": "starts_with"
+                          },
+                          {
+                              "field": ".region",
+                              "value": "us",
+                              "str_operator": "equal"
+                          }
+                      ],
+                      "logical_operation": "AND"
+                  }
+              ],
+              "logical_operation": "OR"
+          }
+      },
+      "merge_strategies": [
+          {
+              "field": ".errors",
+              "strategy": "flat_unique"
+          },
+          {
+              "field": ".users",
+              "strategy": "concat_raw"
+          }
+      ]
+  },
+  "inputs": ["7b212506-23cb-11ed-b300-4ef12c27e273"],
+  "outputs": [
+      {
+          "id": "857b5780-6e2d-11ee-b813-6671faf7df66",
+          "label": "Default"
+      }
+  ]
+}

--- a/pkg/resources/testdata/route.json
+++ b/pkg/resources/testdata/route.json
@@ -1,0 +1,80 @@
+{
+  "id": "563d2374-63ae-11ee-abe2-26dab184329f",
+  "title": "route processor title",
+  "description": "route processor description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 3,
+  "type": "route",
+  "deploy_type": "saas",
+  "user_config": {
+    "conditionals": [
+      {
+        "label": "Error logs",
+        "conditional": {
+          "expressions": [
+            {
+              "field": ".status",
+              "value": "300",
+              "str_operator": "greater_or_equal"
+            },
+            {
+              "field": ".level",
+              "value": "error",
+              "str_operator": "equal"
+            }
+          ],
+          "logical_operation": "OR"
+        },
+        "_output_name": "805821a7"
+      },
+      {
+        "label": "App info logs",
+        "conditional": {
+          "expressions": [
+            {
+              "field": ".level",
+              "value": "info",
+              "str_operator": "equal"
+            },
+            {
+              "expressions": [
+                {
+                  "field": ".app_name",
+                  "value": "service",
+                  "str_operator": "ends_with"
+                },
+                {
+                  "field": ".container_name",
+                  "value": "app",
+                  "str_operator": "equal"
+                }
+              ],
+              "logical_operation": "OR"
+            }
+          ],
+          "logical_operation": "AND"
+        },
+        "_output_name": "c6b6ebe5"
+      }
+    ]
+  },
+  "inputs": [
+    "12d94f50-6c68-11ee-bdee-6671faf7df66",
+    "7b212506-23cb-11ed-b300-4ef12c27e273"
+  ],
+  "outputs": [
+    {
+      "id": "563d2374-63ae-11ee-abe2-26dab184329f._unmatched",
+      "label": "Unmatched"
+    },
+    {
+      "id": "563d2374-63ae-11ee-abe2-26dab184329f.805821a7",
+      "label": "Error logs"
+    },
+    {
+      "id": "563d2374-63ae-11ee-abe2-26dab184329f.c6b6ebe5",
+      "label": "App info logs"
+    }
+  ]
+}

--- a/pkg/resources/testdata/simple_route.json
+++ b/pkg/resources/testdata/simple_route.json
@@ -1,0 +1,45 @@
+{
+  "id": "563d2374-63ae-11ee-abe2-26dab184329f",
+  "title": "route processor title",
+  "description": "route processor description",
+  "account_id": "7b212506-23cb-11ed-b300-4ef12c27e273",
+  "pipeline_id": "0bf994e6-5c7e-11ee-b816-26dab184329f",
+  "generation_id": 3,
+  "type": "route",
+  "deploy_type": "saas",
+  "user_config": {
+    "conditionals": [
+      {
+        "label": "Error logs",
+        "conditional": {
+          "expressions": [
+            {
+              "field": ".status",
+              "value": 300,
+              "str_operator": "greater_or_equal"
+            }
+          ],
+          "logical_operation": "OR"
+        },
+        "_output_name": "805821a7"
+      }
+    ]
+  },
+  "inputs": [
+    "12d94f50-6c68-11ee-bdee-6671faf7df66"
+  ],
+  "outputs": [
+    {
+      "id": "563d2374-63ae-11ee-abe2-26dab184329f._unmatched",
+      "label": "Unmatched"
+    },
+    {
+      "id": "563d2374-63ae-11ee-abe2-26dab184329f.805821a7",
+      "label": "Error logs"
+    },
+    {
+      "id": "563d2374-63ae-11ee-abe2-26dab184329f.c6b6ebe5",
+      "label": "App info logs"
+    }
+  ]
+}


### PR DESCRIPTION
ConvertToTerraformModel populates list fields as empty and object fields as null due to the absence of a Terraform state.
Models that retrieve the list item type or object type from the model object then fail.
To fix this, we need to check if the type is nil and retrieve it directly from the model's schema.