### PR TITLE
chore(ci): Set build desc with sanity param value

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,10 @@ pipeline {
         }
       }
       steps {
+        script {
+          currentBuild.description = "SANITY=${env.SANITY_BUILD}"
+        }
+      
         sh 'FILES_TO_FORMAT=$(gofmt -l .) && echo -e "Files with formatting errors: $FILES_TO_FORMAT" && [ -z "$FILES_TO_FORMAT" ]'
       }
     }


### PR DESCRIPTION
Set the build description with the sanity param value so that
it is easy to see which build is what from the CI list.
