### PR TITLE
refactor: Expose model node types

### DIFF
--- a/internal/provider/destination_resource_definitions.go
+++ b/internal/provider/destination_resource_definitions.go
@@ -9,7 +9,8 @@ import (
 
 func NewAzureBlobStorageDestinationResource() resource.Resource {
 	return &DestinationResource[AzureBlobStorageDestinationModel]{
-		typeName:          "azure_blob_storage",
+		typeName:          AZURE_BLOB_STORAGE_DESTINATION_TYPE_NAME,
+		nodeName:          AZURE_BLOB_STORAGE_DESTINATION_NODE_NAME,
 		fromModelFunc:     AzureBlobStorageFromModel,
 		toModelFunc:       AzureBlobStorageToModel,
 		getIdFunc:         func(m *AzureBlobStorageDestinationModel) basetypes.StringValue { return m.Id },
@@ -20,7 +21,8 @@ func NewAzureBlobStorageDestinationResource() resource.Resource {
 
 func NewBlackholeDestinationResource() resource.Resource {
 	return &DestinationResource[BlackholeDestinationModel]{
-		typeName:          "blackhole",
+		typeName:          BLACKHOLE_DESTINATION_TYPE_NAME,
+		nodeName:          BLACKHOLE_DESTINATION_NODE_NAME,
 		fromModelFunc:     BlackholeDestinationFromModel,
 		toModelFunc:       BlackholeDestinationToModel,
 		getIdFunc:         func(m *BlackholeDestinationModel) basetypes.StringValue { return m.Id },
@@ -31,7 +33,8 @@ func NewBlackholeDestinationResource() resource.Resource {
 
 func NewDatadogLogsDestinationResource() resource.Resource {
 	return &DestinationResource[DatadogLogsDestinationModel]{
-		typeName:          "datadog_logs",
+		typeName:          DATADOG_LOGS_DESTINATION_TYPE_NAME,
+		nodeName:          DATADOG_LOGS_DESTINATION_NODE_NAME,
 		fromModelFunc:     DatadogLogsFromModel,
 		toModelFunc:       DatadogLogsDestinationToModel,
 		getIdFunc:         func(m *DatadogLogsDestinationModel) basetypes.StringValue { return m.Id },
@@ -42,7 +45,8 @@ func NewDatadogLogsDestinationResource() resource.Resource {
 
 func NewDatadogMetricsDestinationResource() resource.Resource {
 	return &DestinationResource[DatadogMetricsDestinationModel]{
-		typeName:          "datadog_metrics",
+		typeName:          DATADOG_METRICS_DESTINATION_TYPE_NAME,
+		nodeName:          DATADOG_METRICS_DESTINATION_NODE_NAME,
 		fromModelFunc:     DatadogMetricsFromModel,
 		toModelFunc:       DatadogMetricsDestinationToModel,
 		getIdFunc:         func(m *DatadogMetricsDestinationModel) basetypes.StringValue { return m.Id },
@@ -53,7 +57,8 @@ func NewDatadogMetricsDestinationResource() resource.Resource {
 
 func NewElasticSearchDestinationResource() resource.Resource {
 	return &DestinationResource[ElasticSearchDestinationModel]{
-		typeName:          "elasticsearch",
+		typeName:          ELASTICSEARCH_DESTINATION_TYPE_NAME,
+		nodeName:          ELASTICSEARCH_DESTINATION_NODE_NAME,
 		fromModelFunc:     ElasticSearchDestinationFromModel,
 		toModelFunc:       ElasticSearchDestinationToModel,
 		getIdFunc:         func(m *ElasticSearchDestinationModel) basetypes.StringValue { return m.Id },
@@ -64,7 +69,8 @@ func NewElasticSearchDestinationResource() resource.Resource {
 
 func NewHoneycombLogsDestinationResource() resource.Resource {
 	return &DestinationResource[HoneycombLogsDestinationModel]{
-		typeName:          "honeycomb_logs",
+		typeName:          HONEYCOMB_LOGS_DESTINATION_TYPE_NAME,
+		nodeName:          HONEYCOMB_LOGS_DESTINATION_NODE_NAME,
 		fromModelFunc:     HoneycombLogsFromModel,
 		toModelFunc:       HoneycombLogsToModel,
 		getIdFunc:         func(m *HoneycombLogsDestinationModel) basetypes.StringValue { return m.Id },
@@ -75,7 +81,8 @@ func NewHoneycombLogsDestinationResource() resource.Resource {
 
 func NewHttpDestinationResource() resource.Resource {
 	return &DestinationResource[HttpDestinationModel]{
-		typeName:          "http",
+		typeName:          HTTP_DESTINATION_TYPE_NAME,
+		nodeName:          HTTP_DESTINATION_NODE_NAME,
 		fromModelFunc:     HttpDestinationFromModel,
 		toModelFunc:       HttpDestinationToModel,
 		getIdFunc:         func(m *HttpDestinationModel) basetypes.StringValue { return m.Id },
@@ -86,7 +93,8 @@ func NewHttpDestinationResource() resource.Resource {
 
 func NewKafkaDestinationResource() resource.Resource {
 	return &DestinationResource[KafkaDestinationModel]{
-		typeName:          "kafka",
+		typeName:          KAFKA_DESTINATION_TYPE_NAME,
+		nodeName:          KAFKA_DESTINATION_NODE_NAME,
 		fromModelFunc:     KafkaDestinationFromModel,
 		toModelFunc:       KafkaDestinationToModel,
 		getIdFunc:         func(m *KafkaDestinationModel) basetypes.StringValue { return m.Id },
@@ -97,7 +105,8 @@ func NewKafkaDestinationResource() resource.Resource {
 
 func NewLokiDestinationResource() resource.Resource {
 	return &DestinationResource[LokiDestinationModel]{
-		typeName:          "loki",
+		typeName:          LOKI_DESTINATION_TYPE_NAME,
+		nodeName:          LOKI_DESTINATION_NODE_NAME,
 		fromModelFunc:     LokiFromModel,
 		toModelFunc:       LokiDestinationToModel,
 		getIdFunc:         func(m *LokiDestinationModel) basetypes.StringValue { return m.Id },
@@ -108,7 +117,8 @@ func NewLokiDestinationResource() resource.Resource {
 
 func NewMezmoDestinationResource() resource.Resource {
 	return &DestinationResource[MezmoDestinationModel]{
-		typeName:          "logs",
+		typeName:          MEZMO_DESTINATION_TYPE_NAME,
+		nodeName:          MEZMO_DESTINATION_NODE_NAME,
 		fromModelFunc:     MezmoDestinationFromModel,
 		toModelFunc:       MezmoDestinationToModel,
 		getIdFunc:         func(m *MezmoDestinationModel) basetypes.StringValue { return m.Id },
@@ -119,7 +129,8 @@ func NewMezmoDestinationResource() resource.Resource {
 
 func NewNewRelicDestinationResource() resource.Resource {
 	return &DestinationResource[NewRelicDestinationModel]{
-		typeName:          "new_relic",
+		typeName:          NEWRELIC_DESTINATION_TYPE_NAME,
+		nodeName:          NEWRELIC_DESTINATION_NODE_NAME,
 		fromModelFunc:     NewRelicDestinationFromModel,
 		toModelFunc:       NewRelicDestinationToModel,
 		getIdFunc:         func(m *NewRelicDestinationModel) basetypes.StringValue { return m.Id },
@@ -130,7 +141,8 @@ func NewNewRelicDestinationResource() resource.Resource {
 
 func NewPrometheusRemoteWriteDestinationResource() resource.Resource {
 	return &DestinationResource[PrometheusRemoteWriteDestinationModel]{
-		typeName:          "prometheus_remote_write",
+		typeName:          PROMETHEUS_REMOTE_WRITE_DESTINATION_TYPE_NAME,
+		nodeName:          PROMETHEUS_REMOTE_WRITE_DESTINATION_NODE_NAME,
 		fromModelFunc:     PrometheusRemoteWriteDestinationFromModel,
 		toModelFunc:       PrometheusRemoteWriteDestinationToModel,
 		getIdFunc:         func(m *PrometheusRemoteWriteDestinationModel) basetypes.StringValue { return m.Id },
@@ -141,7 +153,8 @@ func NewPrometheusRemoteWriteDestinationResource() resource.Resource {
 
 func NewS3DestinationResource() resource.Resource {
 	return &DestinationResource[S3DestinationModel]{
-		typeName:          "s3",
+		typeName:          S3_DESTINATION_TYPE_NAME,
+		nodeName:          S3_DESTINATION_NODE_NAME,
 		fromModelFunc:     S3DestinationFromModel,
 		toModelFunc:       S3DestinationToModel,
 		getIdFunc:         func(m *S3DestinationModel) basetypes.StringValue { return m.Id },
@@ -152,7 +165,8 @@ func NewS3DestinationResource() resource.Resource {
 
 func NewSplunkHecLogsDestinationResource() resource.Resource {
 	return &DestinationResource[SplunkHecLogsDestinationModel]{
-		typeName:          "splunk_hec_logs",
+		typeName:          SPLUNK_HEC_LOGS_DESTINATION_TYPE_NAME,
+		nodeName:          SPLUNK_HEC_LOGS_DESTINATION_NODE_NAME,
 		fromModelFunc:     SplunkHecLogsDestinationFromModel,
 		toModelFunc:       SplunkHecLogsDestinationToModel,
 		getIdFunc:         func(m *SplunkHecLogsDestinationModel) basetypes.StringValue { return m.Id },
@@ -163,7 +177,8 @@ func NewSplunkHecLogsDestinationResource() resource.Resource {
 
 func NewGcpCloudStorageDestinationResource() resource.Resource {
 	return &DestinationResource[GcpCloudStorageDestinationModel]{
-		typeName:          "gcp_cloud_storage",
+		typeName:          GCP_CLOUD_STORAGE_DESTINATION_TYPE_NAME,
+		nodeName:          GCP_CLOUD_STORAGE_DESTINATION_NODE_NAME,
 		fromModelFunc:     GcpCloudStorageDestinationFromModel,
 		toModelFunc:       GcpCloudStorageDestinationToModel,
 		getIdFunc:         func(m *GcpCloudStorageDestinationModel) basetypes.StringValue { return m.Id },

--- a/internal/provider/models/destinations/azure_blob_storage.go
+++ b/internal/provider/models/destinations/azure_blob_storage.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const AZURE_BLOB_STORAGE_DESTINATION_TYPE_NAME = "azure_blob_storage"
+const AZURE_BLOB_STORAGE_DESTINATION_NODE_NAME = "azure-blob-storage"
+
 type AzureBlobStorageDestinationModel struct {
 	Id                  String `tfsdk:"id"`
 	PipelineId          String `tfsdk:"pipeline_id"`
@@ -68,7 +71,7 @@ func AzureBlobStorageFromModel(plan *AzureBlobStorageDestinationModel, previousS
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "azure-blob-storage",
+			Type:        AZURE_BLOB_STORAGE_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/blackhole.go
+++ b/internal/provider/models/destinations/blackhole.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const BLACKHOLE_DESTINATION_NODE_NAME = "blackhole"
+const BLACKHOLE_DESTINATION_TYPE_NAME = BLACKHOLE_DESTINATION_NODE_NAME
+
 type BlackholeDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -28,7 +31,7 @@ func BlackholeDestinationFromModel(plan *BlackholeDestinationModel, previousStat
 	dd := diag.Diagnostics{}
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "blackhole",
+			Type:        BLACKHOLE_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/destinations/datadog_logs.go
+++ b/internal/provider/models/destinations/datadog_logs.go
@@ -10,6 +10,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const DATADOG_LOGS_DESTINATION_TYPE_NAME = "datadog_logs"
+const DATADOG_LOGS_DESTINATION_NODE_NAME = "datadog-logs"
+
 type DatadogLogsDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -49,7 +52,7 @@ func DatadogLogsFromModel(plan *DatadogLogsDestinationModel, previousState *Data
 	dd := diag.Diagnostics{}
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "datadog-logs",
+			Type:        DATADOG_LOGS_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      modelutils.StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/datadog_metrics.go
+++ b/internal/provider/models/destinations/datadog_metrics.go
@@ -10,6 +10,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const DATADOG_METRICS_DESTINATION_TYPE_NAME = "datadog_metrics"
+const DATADOG_METRICS_DESTINATION_NODE_NAME = "datadog-metrics"
+
 type DatadogMetricsDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -43,7 +46,7 @@ func DatadogMetricsFromModel(plan *DatadogMetricsDestinationModel, previousState
 	dd := diag.Diagnostics{}
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "datadog-metrics",
+			Type:        DATADOG_METRICS_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/destinations/elasticsearch.go
+++ b/internal/provider/models/destinations/elasticsearch.go
@@ -15,6 +15,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const ELASTICSEARCH_DESTINATION_TYPE_NAME = "elasticsearch"
+const ELASTICSEARCH_DESTINATION_NODE_NAME = ELASTICSEARCH_DESTINATION_TYPE_NAME
+
 type ElasticSearchDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -117,7 +120,7 @@ func ElasticSearchDestinationFromModel(plan *ElasticSearchDestinationModel, prev
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "elasticsearch",
+			Type:        ELASTICSEARCH_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/gcp_cloud_storage.go
+++ b/internal/provider/models/destinations/gcp_cloud_storage.go
@@ -15,6 +15,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const GCP_CLOUD_STORAGE_DESTINATION_TYPE_NAME = "gcp_cloud_storage"
+const GCP_CLOUD_STORAGE_DESTINATION_NODE_NAME = "gcp-cloud-storage"
+
 type GcpCloudStorageDestinationModel struct {
 	Id                  String `tfsdk:"id"`
 	PipelineId          String `tfsdk:"pipeline_id"`
@@ -96,7 +99,7 @@ func GcpCloudStorageDestinationFromModel(plan *GcpCloudStorageDestinationModel, 
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "gcp-cloud-storage",
+			Type:        GCP_CLOUD_STORAGE_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/honeycomb_logs.go
+++ b/internal/provider/models/destinations/honeycomb_logs.go
@@ -10,6 +10,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const HONEYCOMB_LOGS_DESTINATION_TYPE_NAME = "honeycomb_logs"
+const HONEYCOMB_LOGS_DESTINATION_NODE_NAME = "honeycomb-logs"
+
 type HoneycombLogsDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -44,7 +47,7 @@ func HoneycombLogsFromModel(plan *HoneycombLogsDestinationModel, previousState *
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "honeycomb-logs",
+			Type:        HONEYCOMB_LOGS_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/http.go
+++ b/internal/provider/models/destinations/http.go
@@ -14,6 +14,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const HTTP_DESTINATION_TYPE_NAME = "http"
+const HTTP_DESTINATION_NODE_NAME = HTTP_DESTINATION_TYPE_NAME
+
 type HttpDestinationModel struct {
 	Id           StringValue `tfsdk:"id"`
 	PipelineId   StringValue `tfsdk:"pipeline_id"`
@@ -102,7 +105,7 @@ func HttpDestinationFromModel(plan *HttpDestinationModel, previousState *HttpDes
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "http",
+			Type:        HTTP_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/destinations/kafka.go
+++ b/internal/provider/models/destinations/kafka.go
@@ -17,6 +17,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const KAFKA_DESTINATION_TYPE_NAME = "kafka"
+const KAFKA_DESTINATION_NODE_NAME = KAFKA_DESTINATION_TYPE_NAME
+
 type KafkaDestinationModel struct {
 	Id            String `tfsdk:"id"`
 	PipelineId    String `tfsdk:"pipeline_id"`
@@ -139,7 +142,7 @@ func KafkaDestinationFromModel(plan *KafkaDestinationModel, previousState *Kafka
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "kafka",
+			Type:        KAFKA_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/destinations/loki.go
+++ b/internal/provider/models/destinations/loki.go
@@ -15,6 +15,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const LOKI_DESTINATION_TYPE_NAME = "loki"
+const LOKI_DESTINATION_NODE_NAME = "loki"
+
 type LokiDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -90,7 +93,7 @@ func LokiFromModel(plan *LokiDestinationModel, previousState *LokiDestinationMod
 	dd := diag.Diagnostics{}
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "loki",
+			Type:        LOKI_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/mezmo.go
+++ b/internal/provider/models/destinations/mezmo.go
@@ -16,6 +16,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const MEZMO_DESTINATION_TYPE_NAME = "logs"
+const MEZMO_DESTINATION_NODE_NAME = "mezmo"
+
 type MezmoDestinationModel struct {
 	Id                    String `tfsdk:"id"`
 	PipelineId            String `tfsdk:"pipeline_id"`
@@ -162,7 +165,7 @@ func MezmoDestinationFromModel(plan *MezmoDestinationModel, previousState *Mezmo
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "mezmo",
+			Type:        MEZMO_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/new_relic.go
+++ b/internal/provider/models/destinations/new_relic.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const NEWRELIC_DESTINATION_TYPE_NAME = "new_relic"
+const NEWRELIC_DESTINATION_NODE_NAME = "new-relic"
+
 type NewRelicDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -54,7 +57,7 @@ func NewRelicDestinationFromModel(plan *NewRelicDestinationModel, previousState 
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "new-relic",
+			Type:        NEWRELIC_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/prometheus_remote_write.go
+++ b/internal/provider/models/destinations/prometheus_remote_write.go
@@ -14,6 +14,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const PROMETHEUS_REMOTE_WRITE_DESTINATION_TYPE_NAME = "prometheus_remote_write"
+const PROMETHEUS_REMOTE_WRITE_DESTINATION_NODE_NAME = "prometheus-remote-write"
+
 type PrometheusRemoteWriteDestinationModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -79,7 +82,7 @@ func PrometheusRemoteWriteDestinationFromModel(plan *PrometheusRemoteWriteDestin
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "prometheus-remote-write",
+			Type:        PROMETHEUS_REMOTE_WRITE_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/s3.go
+++ b/internal/provider/models/destinations/s3.go
@@ -14,6 +14,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const S3_DESTINATION_TYPE_NAME = "s3"
+const S3_DESTINATION_NODE_NAME = S3_DESTINATION_TYPE_NAME
+
 type S3DestinationModel struct {
 	Id                  String `tfsdk:"id"`
 	PipelineId          String `tfsdk:"pipeline_id"`
@@ -91,7 +94,7 @@ func S3DestinationFromModel(plan *S3DestinationModel, previousState *S3Destinati
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "s3",
+			Type:        S3_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/destinations/splunk_hec_logs.go
+++ b/internal/provider/models/destinations/splunk_hec_logs.go
@@ -17,6 +17,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const SPLUNK_HEC_LOGS_DESTINATION_TYPE_NAME = "splunk_hec_logs"
+const SPLUNK_HEC_LOGS_DESTINATION_NODE_NAME = "splunk-hec-logs"
+
 type SplunkHecLogsDestinationModel struct {
 	Id                   String `tfsdk:"id"`
 	PipelineId           String `tfsdk:"pipeline_id"`
@@ -120,7 +123,7 @@ func SplunkHecLogsDestinationFromModel(plan *SplunkHecLogsDestinationModel, prev
 
 	component := Destination{
 		BaseNode: BaseNode{
-			Type:        "splunk-hec-logs",
+			Type:        SPLUNK_HEC_LOGS_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/processors/compact_fields.go
+++ b/internal/provider/models/processors/compact_fields.go
@@ -14,6 +14,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const COMPACT_FIELDS_PROCESSOR_NODE_NAME = "compact-fields"
+const COMPACT_FIELDS_PROCESSOR_TYPE_NAME = "compact_fields"
+
 type CompactFieldsProcessorModel struct {
 	Id            String `tfsdk:"id"`
 	PipelineId    String `tfsdk:"pipeline_id"`
@@ -57,7 +60,7 @@ func CompactFieldsProcessorFromModel(plan *CompactFieldsProcessorModel, previous
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "compact-fields",
+			Type:        COMPACT_FIELDS_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  make(map[string]any),

--- a/internal/provider/models/processors/decrypt_fields.go
+++ b/internal/provider/models/processors/decrypt_fields.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const DECRYPT_FIELDS_PROCESSOR_NODE_NAME = "decrypt-fields"
+const DECRYPT_FIELDS_PROCESSOR_TYPE_NAME = "decrypt_fields"
+
 type DecryptFieldsProcessorModel struct {
 	Id             String `tfsdk:"id"`
 	PipelineId     String `tfsdk:"pipeline_id"`
@@ -71,7 +74,7 @@ func DecryptFieldsProcessorFromModel(plan *DecryptFieldsProcessorModel, previous
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "decrypt-fields",
+			Type:        DECRYPT_FIELDS_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/processors/dedupe.go
+++ b/internal/provider/models/processors/dedupe.go
@@ -14,6 +14,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const DEDUPE_PROCESSOR_NODE_NAME = "dedupe"
+const DEDUPE_PROCESSOR_TYPE_NAME = DEDUPE_PROCESSOR_NODE_NAME
+
 type DedupeProcessorModel struct {
 	Id             String `tfsdk:"id"`
 	PipelineId     String `tfsdk:"pipeline_id"`
@@ -66,7 +69,7 @@ func DedupeProcessorFromModel(plan *DedupeProcessorModel, previousState *DedupeP
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "dedupe",
+			Type:        DEDUPE_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  make(map[string]any),

--- a/internal/provider/models/processors/drop_fields.go
+++ b/internal/provider/models/processors/drop_fields.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const DROP_FIELDS_PROCESSOR_NODE_NAME = "drop-fields"
+const DROP_FIELDS_PROCESSOR_TYPE_NAME = "drop_fields"
+
 type DropFieldsProcessorModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -40,7 +43,7 @@ func DropFieldsProcessorFromModel(plan *DropFieldsProcessorModel, previousState 
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "drop-fields",
+			Type:        DROP_FIELDS_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/processors/encrypt_fields.go
+++ b/internal/provider/models/processors/encrypt_fields.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const ENCRYPT_FIELDS_PROCESSOR_NODE_NAME = "encrypt-fields"
+const ENCRYPT_FIELDS_PROCESSOR_TYPE_NAME = "encrypt_fields"
+
 type EncryptFieldsProcessorModel struct {
 	Id             String `tfsdk:"id"`
 	PipelineId     String `tfsdk:"pipeline_id"`
@@ -73,7 +76,7 @@ func EncryptFieldsProcessorFromModel(plan *EncryptFieldsProcessorModel, previous
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "encrypt-fields",
+			Type:        ENCRYPT_FIELDS_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/processors/event_to_metric.go
+++ b/internal/provider/models/processors/event_to_metric.go
@@ -16,6 +16,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const EVENT_TO_METRIC_PROCESSOR_NODE_NAME = "event-to-metric"
+const EVENT_TO_METRIC_PROCESSOR_TYPE_NAME = "event_to_metric"
+
 type EventToMetricProcessorModel struct {
 	Id             StringValue  `tfsdk:"id"`
 	PipelineId     StringValue  `tfsdk:"pipeline_id"`
@@ -141,7 +144,7 @@ func EventToMetricProcessorFromModel(plan *EventToMetricProcessorModel, previous
 	dd := diag.Diagnostics{}
 	component := &Processor{
 		BaseNode: BaseNode{
-			Type:        "event-to-metric",
+			Type:        EVENT_TO_METRIC_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/processors/flatten_fields.go
+++ b/internal/provider/models/processors/flatten_fields.go
@@ -13,6 +13,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const FLATTEN_FIELDS_PROCESSOR_NODE_NAME = "flatten-fields"
+const FLATTEN_FIELDS_PROCESSOR_TYPE_NAME = "flatten_fields"
+
 type FlattenFieldsProcessorModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -52,7 +55,7 @@ func FlattenFieldsProcessorFromModel(plan *FlattenFieldsProcessorModel, previous
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "flatten-fields",
+			Type:        FLATTEN_FIELDS_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  make(map[string]any),

--- a/internal/provider/models/processors/map_fields.go
+++ b/internal/provider/models/processors/map_fields.go
@@ -14,6 +14,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const MAP_FIELDS_PROCESSOR_NODE_NAME = "map-fields"
+const MAP_FIELDS_PROCESSOR_TYPE_NAME = "map_fields"
+
 type MapFieldsProcessorModel struct {
 	Id           StringValue `tfsdk:"id"`
 	PipelineId   StringValue `tfsdk:"pipeline_id"`
@@ -81,7 +84,7 @@ func MapFieldsProcessorFromModel(plan *MapFieldsProcessorModel, previousState *M
 	dd := diag.Diagnostics{}
 	component := &Processor{
 		BaseNode: BaseNode{
-			Type:        "map-fields",
+			Type:        MAP_FIELDS_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  map[string]any{},

--- a/internal/provider/models/processors/metrics_tag_cardinality_limit.go
+++ b/internal/provider/models/processors/metrics_tag_cardinality_limit.go
@@ -27,7 +27,8 @@ type MetricsTagCardinalityLimitProcessorModel struct {
 	Mode         StringValue `tfsdk:"mode" user_config:"true"`
 }
 
-var MetricsTagCardinalityLimitProcessorName = "metrics_tag_cardinality_limit"
+const METRICS_TAG_CARDINALITY_LIMIT_PROCESSOR_TYPE_NAME = "metrics_tag_cardinality_limit"
+const METRICS_TAG_LIMIT_PROCESSOR_NODE_NAME = "metrics-tag-cardinality-limit"
 
 var MetricsTagCardinalityLimitProcessorResourceSchema = schema.Schema{
 	Description: "Limits the cardinality of metric events by either dropping events " +

--- a/internal/provider/models/processors/parse.go
+++ b/internal/provider/models/processors/parse.go
@@ -14,6 +14,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const PARSE_PROCESSOR_NODE_NAME = "parse"
+const PARSE_PROCESSOR_TYPE_NAME = PARSE_PROCESSOR_NODE_NAME
+
 type ParseProcessorModel struct {
 	Id               String `tfsdk:"id"`
 	PipelineId       String `tfsdk:"pipeline_id"`
@@ -44,7 +47,7 @@ func ParseProcessorFromModel(plan *ParseProcessorModel, previousState *ParseProc
 	parser := plan.Parser.ValueString()
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "parse",
+			Type:        PARSE_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/processors/parse_sequentially.go
+++ b/internal/provider/models/processors/parse_sequentially.go
@@ -15,7 +15,8 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-var ParseSequentiallyProcessorName = "parse_sequentially"
+const PARSE_SEQUENTIALLY_PROCESSOR_TYPE_NAME = "parse_sequentially"
+const PARSE_SEQUENTIALLY_PROCESSOR_NODE_NAME = "parse-sequentially"
 
 type ParseSequentiallyProcessorModel struct {
 	Id           String `tfsdk:"id"`
@@ -38,7 +39,7 @@ func ParseSequentiallyProcessorFromModel(plan *ParseSequentiallyProcessorModel, 
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "parse-sequentially",
+			Type:        PARSE_SEQUENTIALLY_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/processors/reduce.go
+++ b/internal/provider/models/processors/reduce.go
@@ -17,6 +17,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const REDUCE_PROCESSOR_NODE_NAME = "reduce"
+const REDUCE_PROCESSOR_TYPE_NAME = REDUCE_PROCESSOR_NODE_NAME
+
 type ReduceProcessorModel struct {
 	Id              StringValue `tfsdk:"id"`
 	PipelineId      StringValue `tfsdk:"pipeline_id"`
@@ -126,7 +129,7 @@ func ReduceProcessorFromModel(plan *ReduceProcessorModel, previousState *ReduceP
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "reduce",
+			Type:        REDUCE_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/processors/route.go
+++ b/internal/provider/models/processors/route.go
@@ -24,7 +24,8 @@ type RouteProcessorModel struct {
 	Conditionals List   `tfsdk:"conditionals" user_config:"true"`
 }
 
-var RouteProcessorName = "route"
+const ROUTE_PROCESSOR_TYPE_NAME = "route"
+const ROUTE_PROCESSOR_NODE_NAME = ROUTE_PROCESSOR_TYPE_NAME
 
 var RouteProcessorResourceSchema = schema.Schema{
 	Description: "Route data based on whether or not it matches logical comparisons.",
@@ -57,7 +58,7 @@ func RouteProcessorFromModel(plan *RouteProcessorModel, previousState *RouteProc
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        RouteProcessorName,
+			Type:        ROUTE_PROCESSOR_TYPE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 		},

--- a/internal/provider/models/processors/sample.go
+++ b/internal/provider/models/processors/sample.go
@@ -18,6 +18,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const SAMPLE_PROCESSOR_NODE_NAME = "sample"
+const SAMPLE_PROCESSOR_TYPE_NAME = SAMPLE_PROCESSOR_NODE_NAME
+
 type SampleProcessorModel struct {
 	Id            String `tfsdk:"id"`
 	PipelineId    String `tfsdk:"pipeline_id"`
@@ -91,7 +94,7 @@ func SampleProcessorFromModel(plan *SampleProcessorModel, previousState *SampleP
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "sample",
+			Type:        SAMPLE_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/processors/script_execution.go
+++ b/internal/provider/models/processors/script_execution.go
@@ -10,6 +10,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const SCRIPT_EXECUTION_PROCESSOR_NODE_NAME = "js-script"
+const SCRIPT_EXECUTION_PROCESSOR_TYPE_NAME = "script_execution"
+
 type ScriptExecutionProcessorModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -38,7 +41,7 @@ func ScriptExecutionProcessorFromModel(plan *ScriptExecutionProcessorModel, prev
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "js-script",
+			Type:        SCRIPT_EXECUTION_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/processors/stringify.go
+++ b/internal/provider/models/processors/stringify.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const STRINGIFY_PROCESSOR_NODE_NAME = "stringify"
+const STRINGIFY_PROCESSOR_TYPE_NAME = STRINGIFY_PROCESSOR_NODE_NAME
+
 type StringifyProcessorModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -27,7 +30,7 @@ func StringifyProcessorFromModel(plan *StringifyProcessorModel, previousState *S
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "stringify",
+			Type:        STRINGIFY_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  make(map[string]any),

--- a/internal/provider/models/processors/unroll.go
+++ b/internal/provider/models/processors/unroll.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const UNROLL_PROCESSOR_NODE_NAME = "unroll"
+const UNROLL_PROCESSOR_TYPE_NAME = UNROLL_PROCESSOR_NODE_NAME
+
 type UnrollProcessorModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -45,7 +48,7 @@ func UnrollProcessorFromModel(plan *UnrollProcessorModel, previousState *UnrollP
 	dd := diag.Diagnostics{}
 	component := Processor{
 		BaseNode: BaseNode{
-			Type:        "unroll",
+			Type:        UNROLL_PROCESSOR_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			Inputs:      StringListValueToStringSlice(plan.Inputs),

--- a/internal/provider/models/sources/agent.go
+++ b/internal/provider/models/sources/agent.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const AGENT_SOURCE_TYPE_NAME = "agent"
+const AGENT_SOURCE_NODE_NAME = "mezmo-agent"
+
 type AgentSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -29,7 +32,7 @@ func AgentSourceFromModel(plan *AgentSourceModel, previousState *AgentSourceMode
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "mezmo-agent",
+			Type:        AGENT_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/azure_event_hub.go
+++ b/internal/provider/models/sources/azure_event_hub.go
@@ -12,6 +12,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const AZURE_EVENT_HUB_SOURCE_TYPE_NAME = "azure_event_hub"
+const AZURE_EVENT_HUB_SOURCE_NODE_NAME = "azure-event-hub"
+
 type AzureEventHubSourceModel struct {
 	Id               String `tfsdk:"id"`
 	PipelineId       String `tfsdk:"pipeline_id"`
@@ -82,7 +85,7 @@ func AzureEventHubSourceFromModel(plan *AzureEventHubSourceModel, previousState 
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "azure-event-hub",
+			Type:        AZURE_EVENT_HUB_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/datadog.go
+++ b/internal/provider/models/sources/datadog.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const DATADOG_SOURCE_NODE_NAME = "mezmo-datadog-source"
+const DATADOG_SOURCE_TYPE_NAME = "datadog"
+
 type DatadogSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -29,7 +32,7 @@ func DatadogSourceFromModel(plan *DatadogSourceModel, previousState *DatadogSour
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "mezmo-datadog-source",
+			Type:        DATADOG_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/demo.go
+++ b/internal/provider/models/sources/demo.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const DEMO_SOURCE_NODE_NAME = "demo-logs"
+const DEMO_SOURCE_TYPE_NAME = "demo"
+
 type DemoSourceModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -37,7 +40,7 @@ func DemoSourceFromModel(plan *DemoSourceModel, previousState *DemoSourceModel) 
 	dd := diag.Diagnostics{}
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "demo-logs",
+			Type:        DEMO_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  map[string]any{"format": plan.Format.ValueString()},

--- a/internal/provider/models/sources/fluent.go
+++ b/internal/provider/models/sources/fluent.go
@@ -12,6 +12,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const FLUENT_SOURCE_TYPE_NAME = "fluent"
+const FLUENT_SOURCE_NODE_NAME = FLUENT_SOURCE_TYPE_NAME
+
 type FluentSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -45,7 +48,7 @@ func FluentSourceFromModel(plan *FluentSourceModel, previousState *FluentSourceM
 	dd := diag.Diagnostics{}
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "fluent",
+			Type:        FLUENT_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/http.go
+++ b/internal/provider/models/sources/http.go
@@ -12,6 +12,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const HTTP_SOURCE_TYPE_NAME = "http"
+const HTTP_SOURCE_NODE_NAME = HTTP_SOURCE_TYPE_NAME
+
 type HttpSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -45,7 +48,7 @@ func HttpSourceFromModel(plan *HttpSourceModel, previousState *HttpSourceModel) 
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "http",
+			Type:        HTTP_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/kafka.go
+++ b/internal/provider/models/sources/kafka.go
@@ -17,6 +17,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const KAFKA_SOURCE_TYPE_NAME = "kafka"
+const KAFKA_SOURCE_NODE_NAME = KAFKA_SOURCE_TYPE_NAME
+
 type KafkaSourceModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -137,7 +140,7 @@ func KafkaSourceFromModel(plan *KafkaSourceModel, previousState *KafkaSourceMode
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "kafka",
+			Type:        KAFKA_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/kinesis_firehose.go
+++ b/internal/provider/models/sources/kinesis_firehose.go
@@ -13,6 +13,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const KINESIS_FIREHOSE_SOURCE_TYPE_NAME = "kinesis_firehose"
+const KINESIS_FIREHOSE_SOURCE_NODE_NAME = "kinesis-firehose"
+
 type KinesisFirehoseSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -44,7 +47,7 @@ func KinesisFirehoseSourceFromModel(plan *KinesisFirehoseSourceModel, previousSt
 	dd := diag.Diagnostics{}
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "kinesis-firehose",
+			Type:        KINESIS_FIREHOSE_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/log-analysis.go
+++ b/internal/provider/models/sources/log-analysis.go
@@ -7,6 +7,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const LOG_ANALYSIS_SOURCE_TYPE_NAME = "log_analysis"
+const LOG_ANALYSIS_SOURCE_NODE_NAME = "log-analysis"
+
 type LogAnalysisSourceModel struct {
 	Id           StringValue `tfsdk:"id"`
 	PipelineId   StringValue `tfsdk:"pipeline_id"`
@@ -24,7 +27,7 @@ func LogAnalysisSourceFromModel(plan *LogAnalysisSourceModel, previousState *Log
 	dd := diag.Diagnostics{}
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "log-analysis",
+			Type:        LOG_ANALYSIS_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig:  map[string]any{},

--- a/internal/provider/models/sources/logstash.go
+++ b/internal/provider/models/sources/logstash.go
@@ -12,6 +12,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const LOGSTASH_SOURCE_TYPE_NAME = "logstash"
+const LOGSTASH_SOURCE_NODE_NAME = LOGSTASH_SOURCE_TYPE_NAME
+
 type LogStashSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -41,7 +44,7 @@ func LogStashSourceFromModel(plan *LogStashSourceModel, previousState *LogStashS
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "logstash",
+			Type:        LOGSTASH_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/prometheus_remote_write.go
+++ b/internal/provider/models/sources/prometheus_remote_write.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const PROMETHEUS_REMOTE_WRITE_SOURCE_TYPE_NAME = "prometheus_remote_write"
+const PROMETHEUS_REMOTE_WRITE_SOURCE_NODE_NAME = "prometheus-remote-write"
+
 type PrometheusRemoteWriteSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -29,7 +32,7 @@ func PrometheusRemoteWriteSourceFromModel(plan *PrometheusRemoteWriteSourceModel
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "prometheus-remote-write",
+			Type:        PROMETHEUS_REMOTE_WRITE_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/s3.go
+++ b/internal/provider/models/sources/s3.go
@@ -15,6 +15,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const S3_SOURCE_TYPE_NAME = "s3"
+const S3_SOURCE_NODE_NAME = S3_SOURCE_TYPE_NAME
+
 type S3SourceModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -72,7 +75,7 @@ func S3SourceFromModel(plan *S3SourceModel, previousState *S3SourceModel) (*Sour
 	auth := plan.Auth.Attributes()
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "s3",
+			Type:        S3_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/splunk-hec.go
+++ b/internal/provider/models/sources/splunk-hec.go
@@ -9,6 +9,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const SPLUNK_HEC_SOURCE_TYPE_NAME = "splunk_hec"
+const SPLUNK_HEC_SOURCE_NODE_NAME = "splunk-hec"
+
 type SplunkHecSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -31,7 +34,7 @@ func SplunkHecSourceFromModel(plan *SplunkHecSourceModel, previousState *SplunkH
 	dd := diag.Diagnostics{}
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "splunk-hec",
+			Type:        SPLUNK_HEC_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/sqs.go
+++ b/internal/provider/models/sources/sqs.go
@@ -13,6 +13,9 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 )
 
+const SQS_SOURCE_TYPE_NAME = "sqs"
+const SQS_SOURCE_NODE_NAME = SQS_SOURCE_TYPE_NAME
+
 type SQSSourceModel struct {
 	Id           String `tfsdk:"id"`
 	PipelineId   String `tfsdk:"pipeline_id"`
@@ -67,7 +70,7 @@ func SQSSourceFromModel(plan *SQSSourceModel, previousState *SQSSourceModel) (*S
 	auth_secret_access_key, _ := auth["secret_access_key"].(basetypes.StringValue)
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "sqs",
+			Type:        SQS_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/models/sources/test/fluent_test.go
+++ b/internal/provider/models/sources/test/fluent_test.go
@@ -85,7 +85,7 @@ func TestFluentSource(t *testing.T) {
 					resource "mezmo_pipeline" "test_parent" {
 						title = "parent pipeline"
 					}
-					resource "mezmo_http_source" "parent_source" {
+					resource "mezmo_fluent_source" "parent_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "my http title"
 						description = "my http description"
@@ -94,7 +94,7 @@ func TestFluentSource(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared source"
 						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_http_source.parent_source.gateway_route_id
+						gateway_route_id = mezmo_fluent_source.parent_source.gateway_route_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
@@ -106,7 +106,7 @@ func TestFluentSource(t *testing.T) {
 						"generation_id":    "0",
 						"decoding":         "json",
 						"capture_metadata": "false",
-						"gateway_route_id": "#mezmo_http_source.parent_source.gateway_route_id",
+						"gateway_route_id": "#mezmo_fluent_source.parent_source.gateway_route_id",
 					}),
 				),
 			},
@@ -127,13 +127,13 @@ func TestFluentSource(t *testing.T) {
 					resource "mezmo_fluent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_http_source.parent_source.gateway_route_id
+						gateway_route_id = mezmo_fluent_source.parent_source.gateway_route_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_fluent_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_http_source.parent_source.gateway_route_id",
+						"gateway_route_id": "#mezmo_fluent_source.parent_source.gateway_route_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/webhook.go
+++ b/internal/provider/models/sources/webhook.go
@@ -11,6 +11,9 @@ import (
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const WEBHOOK_SOURCE_TYPE_NAME = "webhook"
+const WEBHOOK_SOURCE_NODE_NAME = WEBHOOK_SOURCE_TYPE_NAME
+
 type WebhookSourceModel struct {
 	Id              String `tfsdk:"id"`
 	PipelineId      String `tfsdk:"pipeline_id"`
@@ -42,7 +45,7 @@ func WebhookSourceFromModel(plan *WebhookSourceModel, previousState *WebhookSour
 
 	component := Source{
 		BaseNode: BaseNode{
-			Type:        "webhook",
+			Type:        WEBHOOK_SOURCE_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
 			UserConfig: map[string]any{

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -27,6 +28,10 @@ type PipelineResource struct {
 }
 
 func (r *PipelineResource) TypeName() string {
+	return PROVIDER_TYPE_NAME + "_pipeline"
+}
+
+func (r *PipelineResource) NodeType() string {
 	return "pipeline"
 }
 
@@ -116,8 +121,8 @@ func (r *PipelineResource) Delete(ctx context.Context, req resource.DeleteReques
 }
 
 // Metadata implements resource.Resource.
-func (*PipelineResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_pipeline"
+func (r *PipelineResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = r.TypeName()
 }
 
 // Read implements resource.Resource.

--- a/internal/provider/processor_resource_definitions.go
+++ b/internal/provider/processor_resource_definitions.go
@@ -9,7 +9,8 @@ import (
 
 func NewDedupeProcessorResource() resource.Resource {
 	return &ProcessorResource[DedupeProcessorModel]{
-		typeName:          "dedupe",
+		typeName:          DEDUPE_PROCESSOR_TYPE_NAME,
+		nodeName:          DEDUPE_PROCESSOR_NODE_NAME,
 		fromModelFunc:     DedupeProcessorFromModel,
 		toModelFunc:       DedupeProcessorToModel,
 		getIdFunc:         func(m *DedupeProcessorModel) basetypes.StringValue { return m.Id },
@@ -20,7 +21,8 @@ func NewDedupeProcessorResource() resource.Resource {
 
 func NewDropFieldsProcessorResource() resource.Resource {
 	return &ProcessorResource[DropFieldsProcessorModel]{
-		typeName:          "drop_fields",
+		typeName:          DROP_FIELDS_PROCESSOR_TYPE_NAME,
+		nodeName:          DROP_FIELDS_PROCESSOR_NODE_NAME,
 		fromModelFunc:     DropFieldsProcessorFromModel,
 		toModelFunc:       DropFieldsProcessorToModel,
 		getIdFunc:         func(m *DropFieldsProcessorModel) basetypes.StringValue { return m.Id },
@@ -31,7 +33,8 @@ func NewDropFieldsProcessorResource() resource.Resource {
 
 func NewFlattenFieldsProcessorResource() resource.Resource {
 	return &ProcessorResource[FlattenFieldsProcessorModel]{
-		typeName:          "flatten_fields",
+		typeName:          FLATTEN_FIELDS_PROCESSOR_TYPE_NAME,
+		nodeName:          FLATTEN_FIELDS_PROCESSOR_NODE_NAME,
 		fromModelFunc:     FlattenFieldsProcessorFromModel,
 		toModelFunc:       FlattenFieldsProcessorToModel,
 		getIdFunc:         func(m *FlattenFieldsProcessorModel) basetypes.StringValue { return m.Id },
@@ -42,7 +45,8 @@ func NewFlattenFieldsProcessorResource() resource.Resource {
 
 func NewMapFieldsProcessorResource() resource.Resource {
 	return &ProcessorResource[MapFieldsProcessorModel]{
-		typeName:          "map_fields",
+		typeName:          MAP_FIELDS_PROCESSOR_TYPE_NAME,
+		nodeName:          MAP_FIELDS_PROCESSOR_NODE_NAME,
 		fromModelFunc:     MapFieldsProcessorFromModel,
 		toModelFunc:       MapFieldsProcessorToModel,
 		getIdFunc:         func(m *MapFieldsProcessorModel) basetypes.StringValue { return m.Id },
@@ -53,7 +57,8 @@ func NewMapFieldsProcessorResource() resource.Resource {
 
 func NewSampleProcessorResource() resource.Resource {
 	return &ProcessorResource[SampleProcessorModel]{
-		typeName:          "sample",
+		typeName:          SAMPLE_PROCESSOR_TYPE_NAME,
+		nodeName:          SAMPLE_PROCESSOR_NODE_NAME,
 		fromModelFunc:     SampleProcessorFromModel,
 		toModelFunc:       SampleProcessorToModel,
 		getIdFunc:         func(m *SampleProcessorModel) basetypes.StringValue { return m.Id },
@@ -64,7 +69,8 @@ func NewSampleProcessorResource() resource.Resource {
 
 func NewStringifyProcessorResource() resource.Resource {
 	return &ProcessorResource[StringifyProcessorModel]{
-		typeName:          "stringify",
+		typeName:          STRINGIFY_PROCESSOR_TYPE_NAME,
+		nodeName:          STRINGIFY_PROCESSOR_NODE_NAME,
 		fromModelFunc:     StringifyProcessorFromModel,
 		toModelFunc:       StringifyProcessorToModel,
 		getIdFunc:         func(m *StringifyProcessorModel) basetypes.StringValue { return m.Id },
@@ -75,7 +81,8 @@ func NewStringifyProcessorResource() resource.Resource {
 
 func NewScriptExecutionProcessorResource() resource.Resource {
 	return &ProcessorResource[ScriptExecutionProcessorModel]{
-		typeName:          "script_execution",
+		typeName:          SCRIPT_EXECUTION_PROCESSOR_TYPE_NAME,
+		nodeName:          SCRIPT_EXECUTION_PROCESSOR_NODE_NAME,
 		fromModelFunc:     ScriptExecutionProcessorFromModel,
 		toModelFunc:       ScriptExecutionProcessorToModel,
 		getIdFunc:         func(m *ScriptExecutionProcessorModel) basetypes.StringValue { return m.Id },
@@ -86,7 +93,8 @@ func NewScriptExecutionProcessorResource() resource.Resource {
 
 func NewUnrollProcessorResource() resource.Resource {
 	return &ProcessorResource[UnrollProcessorModel]{
-		typeName:          "unroll",
+		typeName:          UNROLL_PROCESSOR_TYPE_NAME,
+		nodeName:          UNROLL_PROCESSOR_NODE_NAME,
 		fromModelFunc:     UnrollProcessorFromModel,
 		toModelFunc:       UnrollProcessorToModel,
 		getIdFunc:         func(m *UnrollProcessorModel) basetypes.StringValue { return m.Id },
@@ -97,7 +105,8 @@ func NewUnrollProcessorResource() resource.Resource {
 
 func NewCompactFieldsProcessorResource() resource.Resource {
 	return &ProcessorResource[CompactFieldsProcessorModel]{
-		typeName:          "compact_fields",
+		typeName:          COMPACT_FIELDS_PROCESSOR_TYPE_NAME,
+		nodeName:          COMPACT_FIELDS_PROCESSOR_NODE_NAME,
 		fromModelFunc:     CompactFieldsProcessorFromModel,
 		toModelFunc:       CompactFieldsProcessorToModel,
 		getIdFunc:         func(m *CompactFieldsProcessorModel) basetypes.StringValue { return m.Id },
@@ -108,7 +117,8 @@ func NewCompactFieldsProcessorResource() resource.Resource {
 
 func NewDecryptFieldsProcessorResource() resource.Resource {
 	return &ProcessorResource[DecryptFieldsProcessorModel]{
-		typeName:          "decrypt_fields",
+		typeName:          DECRYPT_FIELDS_PROCESSOR_TYPE_NAME,
+		nodeName:          DECRYPT_FIELDS_PROCESSOR_NODE_NAME,
 		fromModelFunc:     DecryptFieldsProcessorFromModel,
 		toModelFunc:       DecryptFieldsProcessorToModel,
 		getIdFunc:         func(m *DecryptFieldsProcessorModel) basetypes.StringValue { return m.Id },
@@ -119,7 +129,8 @@ func NewDecryptFieldsProcessorResource() resource.Resource {
 
 func NewEncryptFieldsProcessorResource() resource.Resource {
 	return &ProcessorResource[EncryptFieldsProcessorModel]{
-		typeName:          "encrypt_fields",
+		typeName:          ENCRYPT_FIELDS_PROCESSOR_TYPE_NAME,
+		nodeName:          ENCRYPT_FIELDS_PROCESSOR_NODE_NAME,
 		fromModelFunc:     EncryptFieldsProcessorFromModel,
 		toModelFunc:       EncryptFieldsProcessorToModel,
 		getIdFunc:         func(m *EncryptFieldsProcessorModel) basetypes.StringValue { return m.Id },
@@ -130,7 +141,8 @@ func NewEncryptFieldsProcessorResource() resource.Resource {
 
 func NewParseProcessorResource() resource.Resource {
 	return &ProcessorResource[ParseProcessorModel]{
-		typeName:          "parse",
+		typeName:          PARSE_PROCESSOR_TYPE_NAME,
+		nodeName:          PARSE_PROCESSOR_NODE_NAME,
 		fromModelFunc:     ParseProcessorFromModel,
 		toModelFunc:       ParseProcessorToModel,
 		getIdFunc:         func(m *ParseProcessorModel) basetypes.StringValue { return m.Id },
@@ -141,7 +153,8 @@ func NewParseProcessorResource() resource.Resource {
 
 func NewReduceProcessorResource() resource.Resource {
 	return &ProcessorResource[ReduceProcessorModel]{
-		typeName:          "reduce",
+		typeName:          REDUCE_PROCESSOR_TYPE_NAME,
+		nodeName:          REDUCE_PROCESSOR_NODE_NAME,
 		fromModelFunc:     ReduceProcessorFromModel,
 		toModelFunc:       ReduceProcessorToModel,
 		getIdFunc:         func(m *ReduceProcessorModel) basetypes.StringValue { return m.Id },
@@ -152,7 +165,8 @@ func NewReduceProcessorResource() resource.Resource {
 
 func NewRouteProcessorResource() resource.Resource {
 	return &ProcessorResource[RouteProcessorModel]{
-		typeName:          RouteProcessorName,
+		typeName:          ROUTE_PROCESSOR_TYPE_NAME,
+		nodeName:          ROUTE_PROCESSOR_NODE_NAME,
 		fromModelFunc:     RouteProcessorFromModel,
 		toModelFunc:       RouteProcessorToModel,
 		getIdFunc:         func(m *RouteProcessorModel) basetypes.StringValue { return m.Id },
@@ -163,7 +177,8 @@ func NewRouteProcessorResource() resource.Resource {
 
 func NewParseSequentiallyProcessorResource() resource.Resource {
 	return &ProcessorResource[ParseSequentiallyProcessorModel]{
-		typeName:          ParseSequentiallyProcessorName,
+		typeName:          PARSE_SEQUENTIALLY_PROCESSOR_TYPE_NAME,
+		nodeName:          PARSE_SEQUENTIALLY_PROCESSOR_NODE_NAME,
 		fromModelFunc:     ParseSequentiallyProcessorFromModel,
 		toModelFunc:       ParseSequentiallyProcessorToModel,
 		getIdFunc:         func(m *ParseSequentiallyProcessorModel) basetypes.StringValue { return m.Id },
@@ -174,7 +189,8 @@ func NewParseSequentiallyProcessorResource() resource.Resource {
 
 func NewMetricsTagCardinalityLimitProcessorResource() resource.Resource {
 	return &ProcessorResource[MetricsTagCardinalityLimitProcessorModel]{
-		typeName:          MetricsTagCardinalityLimitProcessorName,
+		typeName:          METRICS_TAG_CARDINALITY_LIMIT_PROCESSOR_TYPE_NAME,
+		nodeName:          METRICS_TAG_LIMIT_PROCESSOR_NODE_NAME,
 		fromModelFunc:     MetricsTagCardinalityLimitProcessorFromModel,
 		toModelFunc:       MetricsTagCardinalityLimitProcessorToModel,
 		getIdFunc:         func(m *MetricsTagCardinalityLimitProcessorModel) basetypes.StringValue { return m.Id },
@@ -185,7 +201,8 @@ func NewMetricsTagCardinalityLimitProcessorResource() resource.Resource {
 
 func NewEventToMetricProcessorResource() resource.Resource {
 	return &ProcessorResource[EventToMetricProcessorModel]{
-		typeName:          "event_to_metric",
+		typeName:          EVENT_TO_METRIC_PROCESSOR_TYPE_NAME,
+		nodeName:          EVENT_TO_METRIC_PROCESSOR_NODE_NAME,
 		fromModelFunc:     EventToMetricProcessorFromModel,
 		toModelFunc:       EventToMetricProcessorToModel,
 		getIdFunc:         func(m *EventToMetricProcessorModel) basetypes.StringValue { return m.Id },

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mezmo/terraform-provider-mezmo/internal/client"
 )
 
+const PROVIDER_TYPE_NAME = "mezmo"
+
 var _ provider.Provider = &MezmoProvider{}
 
 // MezmoProvider defines the provider implementation.
@@ -35,7 +37,7 @@ type MezmoProviderModel struct {
 }
 
 func (p *MezmoProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "mezmo"
+	resp.TypeName = PROVIDER_TYPE_NAME
 	resp.Version = p.version
 }
 

--- a/internal/provider/source_resource_definitions.go
+++ b/internal/provider/source_resource_definitions.go
@@ -9,7 +9,8 @@ import (
 
 func NewDemoSourceResource() resource.Resource {
 	return &SourceResource[DemoSourceModel]{
-		typeName:          "demo",
+		typeName:          DEMO_SOURCE_TYPE_NAME,
+		nodeName:          DEMO_SOURCE_NODE_NAME,
 		fromModelFunc:     DemoSourceFromModel,
 		toModelFunc:       DemoSourceToModel,
 		getIdFunc:         func(m *DemoSourceModel) basetypes.StringValue { return m.Id },
@@ -20,7 +21,8 @@ func NewDemoSourceResource() resource.Resource {
 
 func NewAgentSourceResource() resource.Resource {
 	return &SourceResource[AgentSourceModel]{
-		typeName:          "agent",
+		typeName:          AGENT_SOURCE_TYPE_NAME,
+		nodeName:          AGENT_SOURCE_NODE_NAME,
 		fromModelFunc:     AgentSourceFromModel,
 		toModelFunc:       AgentSourceToModel,
 		getIdFunc:         func(m *AgentSourceModel) basetypes.StringValue { return m.Id },
@@ -31,7 +33,8 @@ func NewAgentSourceResource() resource.Resource {
 
 func NewKafkaSourceResource() resource.Resource {
 	return &SourceResource[KafkaSourceModel]{
-		typeName:          "kafka",
+		typeName:          KAFKA_SOURCE_TYPE_NAME,
+		nodeName:          KAFKA_SOURCE_NODE_NAME,
 		fromModelFunc:     KafkaSourceFromModel,
 		toModelFunc:       KafkaSourceToModel,
 		getIdFunc:         func(m *KafkaSourceModel) basetypes.StringValue { return m.Id },
@@ -42,7 +45,8 @@ func NewKafkaSourceResource() resource.Resource {
 
 func NewPrometheusRemoteWriteSourceResource() resource.Resource {
 	return &SourceResource[PrometheusRemoteWriteSourceModel]{
-		typeName:          "prometheus_remote_write",
+		typeName:          PROMETHEUS_REMOTE_WRITE_SOURCE_TYPE_NAME,
+		nodeName:          PROMETHEUS_REMOTE_WRITE_SOURCE_NODE_NAME,
 		fromModelFunc:     PrometheusRemoteWriteSourceFromModel,
 		toModelFunc:       PrometheusRemoteWriteSourceToModel,
 		getIdFunc:         func(m *PrometheusRemoteWriteSourceModel) basetypes.StringValue { return m.Id },
@@ -53,7 +57,8 @@ func NewPrometheusRemoteWriteSourceResource() resource.Resource {
 
 func NewS3SourceResource() resource.Resource {
 	return &SourceResource[S3SourceModel]{
-		typeName:          "s3",
+		typeName:          S3_SOURCE_TYPE_NAME,
+		nodeName:          S3_SOURCE_NODE_NAME,
 		fromModelFunc:     S3SourceFromModel,
 		toModelFunc:       S3SourceToModel,
 		getIdFunc:         func(m *S3SourceModel) basetypes.StringValue { return m.Id },
@@ -64,7 +69,8 @@ func NewS3SourceResource() resource.Resource {
 
 func NewHttpSourceResource() resource.Resource {
 	return &SourceResource[HttpSourceModel]{
-		typeName:          "http",
+		typeName:          HTTP_SOURCE_TYPE_NAME,
+		nodeName:          HTTP_SOURCE_NODE_NAME,
 		fromModelFunc:     HttpSourceFromModel,
 		toModelFunc:       HttpSourceToModel,
 		getIdFunc:         func(m *HttpSourceModel) basetypes.StringValue { return m.Id },
@@ -75,7 +81,8 @@ func NewHttpSourceResource() resource.Resource {
 
 func NewSQSSourceResource() resource.Resource {
 	return &SourceResource[SQSSourceModel]{
-		typeName:          "sqs",
+		typeName:          SQS_SOURCE_TYPE_NAME,
+		nodeName:          SQS_SOURCE_NODE_NAME,
 		fromModelFunc:     SQSSourceFromModel,
 		toModelFunc:       SQSSourceToModel,
 		getIdFunc:         func(m *SQSSourceModel) basetypes.StringValue { return m.Id },
@@ -86,7 +93,8 @@ func NewSQSSourceResource() resource.Resource {
 
 func NewSplunkHecSourceResource() resource.Resource {
 	return &SourceResource[SplunkHecSourceModel]{
-		typeName:          "splunk_hec",
+		typeName:          SPLUNK_HEC_SOURCE_TYPE_NAME,
+		nodeName:          SPLUNK_HEC_SOURCE_NODE_NAME,
 		fromModelFunc:     SplunkHecSourceFromModel,
 		toModelFunc:       SplunkHecSourceToModel,
 		getIdFunc:         func(m *SplunkHecSourceModel) basetypes.StringValue { return m.Id },
@@ -97,7 +105,8 @@ func NewSplunkHecSourceResource() resource.Resource {
 
 func NewLogStashSourceResource() resource.Resource {
 	return &SourceResource[LogStashSourceModel]{
-		typeName:          "logstash",
+		typeName:          LOGSTASH_SOURCE_TYPE_NAME,
+		nodeName:          LOGSTASH_SOURCE_NODE_NAME,
 		fromModelFunc:     LogStashSourceFromModel,
 		toModelFunc:       LogStashSourceToModel,
 		getIdFunc:         func(m *LogStashSourceModel) basetypes.StringValue { return m.Id },
@@ -108,7 +117,8 @@ func NewLogStashSourceResource() resource.Resource {
 
 func NewFluentSourceResource() resource.Resource {
 	return &SourceResource[FluentSourceModel]{
-		typeName:          "fluent",
+		typeName:          FLUENT_SOURCE_TYPE_NAME,
+		nodeName:          FLUENT_SOURCE_NODE_NAME,
 		fromModelFunc:     FluentSourceFromModel,
 		toModelFunc:       FluentSourceToModel,
 		getIdFunc:         func(m *FluentSourceModel) basetypes.StringValue { return m.Id },
@@ -119,7 +129,8 @@ func NewFluentSourceResource() resource.Resource {
 
 func NewAzureEventHubSourceResource() resource.Resource {
 	return &SourceResource[AzureEventHubSourceModel]{
-		typeName:          "azure_event_hub",
+		typeName:          AZURE_EVENT_HUB_SOURCE_TYPE_NAME,
+		nodeName:          AZURE_EVENT_HUB_SOURCE_NODE_NAME,
 		fromModelFunc:     AzureEventHubSourceFromModel,
 		toModelFunc:       AzureEventHubSourceToModel,
 		getIdFunc:         func(m *AzureEventHubSourceModel) basetypes.StringValue { return m.Id },
@@ -130,7 +141,8 @@ func NewAzureEventHubSourceResource() resource.Resource {
 
 func NewKinesisFirehoseSourceResource() resource.Resource {
 	return &SourceResource[KinesisFirehoseSourceModel]{
-		typeName:          "kinesis_firehose",
+		typeName:          KINESIS_FIREHOSE_SOURCE_TYPE_NAME,
+		nodeName:          KINESIS_FIREHOSE_SOURCE_NODE_NAME,
 		fromModelFunc:     KinesisFirehoseSourceFromModel,
 		toModelFunc:       KinesisFirehoseSourceToModel,
 		getIdFunc:         func(m *KinesisFirehoseSourceModel) basetypes.StringValue { return m.Id },
@@ -141,7 +153,8 @@ func NewKinesisFirehoseSourceResource() resource.Resource {
 
 func NewLogAnalysisSourceResource() resource.Resource {
 	return &SourceResource[LogAnalysisSourceModel]{
-		typeName:          "log_analysis",
+		typeName:          LOG_ANALYSIS_SOURCE_TYPE_NAME,
+		nodeName:          LOG_ANALYSIS_SOURCE_NODE_NAME,
 		fromModelFunc:     LogAnalysisSourceFromModel,
 		toModelFunc:       LogAnalysisSourceToModel,
 		getIdFunc:         func(m *LogAnalysisSourceModel) basetypes.StringValue { return m.Id },
@@ -152,7 +165,8 @@ func NewLogAnalysisSourceResource() resource.Resource {
 
 func NewWebhookSourceResource() resource.Resource {
 	return &SourceResource[WebhookSourceModel]{
-		typeName:          "webhook",
+		typeName:          WEBHOOK_SOURCE_TYPE_NAME,
+		nodeName:          WEBHOOK_SOURCE_NODE_NAME,
 		fromModelFunc:     WebhookSourceFromModel,
 		toModelFunc:       WebhookSourceToModel,
 		getIdFunc:         func(m *WebhookSourceModel) basetypes.StringValue { return m.Id },
@@ -163,7 +177,8 @@ func NewWebhookSourceResource() resource.Resource {
 
 func NewDatadogSourceResource() resource.Resource {
 	return &SourceResource[DatadogSourceModel]{
-		typeName:          "datadog",
+		typeName:          DATADOG_SOURCE_TYPE_NAME,
+		nodeName:          DATADOG_SOURCE_NODE_NAME,
 		fromModelFunc:     DatadogSourceFromModel,
 		toModelFunc:       DatadogSourceToModel,
 		getIdFunc:         func(m *DatadogSourceModel) basetypes.StringValue { return m.Id },

--- a/pkg/resources/convertible_test.go
+++ b/pkg/resources/convertible_test.go
@@ -63,15 +63,15 @@ func TestConvertToTerraformModel(t *testing.T) {
 func loadResources(t *testing.T) map[string]*reflect.Value {
 	resList := make(map[string]*reflect.Value)
 	pipeline := reflect.ValueOf(*loadJsonFile[PipelineApiModel](t, testdataPath, "pipeline.json"))
-	resList["pipeline"] = &pipeline
+	resList["mezmo_pipeline"] = &pipeline
 	addToMap(t, resList, loadDirFiles[ProcessorApiModel](t, processorsPath, func(filename string) string {
-		return fmt.Sprintf("%s_processor", filename)
+		return fmt.Sprintf("mezmo_%s_processor", filename)
 	}))
 	addToMap(t, resList, loadDirFiles[SourceApiModel](t, sourcesPath, func(filename string) string {
-		return fmt.Sprintf("%s_source", filename)
+		return fmt.Sprintf("mezmo_%s_source", filename)
 	}))
 	addToMap(t, resList, loadDirFiles[DestinationApiModel](t, destinationsPath, func(filename string) string {
-		return fmt.Sprintf("%s_destination", filename)
+		return fmt.Sprintf("mezmo_%s_destination", filename)
 	}))
 	return resList
 }
@@ -140,20 +140,4 @@ func TestConvertibleResources(t *testing.T) {
 			)
 		}
 	}
-}
-
-func findConvertibleResource(t *testing.T, resourceTypeName string) ConvertibleResourceDef {
-	t.Helper()
-	convResources, err := ConvertibleResources()
-	if err != nil {
-		t.Fatal("no convertible resources found")
-	}
-
-	for _, res := range convResources {
-		if res.TypeName() == resourceTypeName {
-			return res
-		}
-	}
-	t.Fatalf("resource %s not found", resourceTypeName)
-	return nil
 }


### PR DESCRIPTION
Expose the model node type to be consumed by the pipeline export repository. The existing TypeName method now returns the resource Terraform type

Ref: LOG-18419