### PR TITLE
fix(test): clean up test cacheKey values

### DIFF
--- a/internal/provider/models/destinations/test/datadog_metrics_test.go
+++ b/internal/provider/models/destinations/test/datadog_metrics_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDatadogMetricsDestinationResource(t *testing.T) {
+	const cacheKey = "datadog_metrics_destination_resource"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { TestPreCheck(t) },
@@ -61,7 +62,7 @@ func TestDatadogMetricsDestinationResource(t *testing.T) {
 
 			// Test defaults
 			{
-				Config: SetCachedConfig("http_destination_resources", `
+				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
 						title = "pipeline"
 					}
@@ -93,7 +94,7 @@ func TestDatadogMetricsDestinationResource(t *testing.T) {
 
 			// Update all fields
 			{
-				Config: GetCachedConfig("http_destination_resources") + `
+				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_datadog_metrics_destination" "my_destination" {
 						title = "new title"
 						description = "new metrics description"

--- a/internal/provider/models/sources/test/agent_test.go
+++ b/internal/provider/models/sources/test/agent_test.go
@@ -68,7 +68,7 @@ func TestAgentSourceResource(t *testing.T) {
 			},
 			// Supply gateway_route_id
 			{
-				Config: SetCachedConfig("Supply gateway_route_id", `
+				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
 						title = "parent pipeline"
 					}
@@ -98,7 +98,7 @@ func TestAgentSourceResource(t *testing.T) {
 			},
 			// Updating gateway_route_id is not allowed
 			{
-				Config: GetCachedConfig("Supply gateway_route_id") + `
+				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_agent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A new title"
@@ -108,7 +108,7 @@ func TestAgentSourceResource(t *testing.T) {
 			},
 			// gateway_route_id can be specified if it's the same value
 			{
-				Config: GetCachedConfig("Supply gateway_route_id") + `
+				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_agent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title again"


### PR DESCRIPTION
Cleaning up the cacheKey values used in some of the test cases to follow our testing guidelines.

Ref: LOG-18529