### PR TITLE
fix(reduce): fix flush_condition parsing to read from when

### DIFF
--- a/internal/provider/models/processors/reduce.go
+++ b/internal/provider/models/processors/reduce.go
@@ -290,16 +290,17 @@ func ReduceProcessorToModel(plan *ReduceProcessorModel, component *Processor) {
 
 	if component.UserConfig["flush_condition"] != nil {
 		flushCondition := component.UserConfig["flush_condition"].(map[string]any)
-
-		conditional := unwindConditionalToModel(flushCondition["conditional"].(map[string]any))
-
-		plan.FlushCondition = NewObjectValueMust(map[string]attr.Type{
-			"when":        StringType{},
-			"conditional": conditional.Type(context.Background()),
-		}, map[string]attr.Value{
-			"when":        NewStringValue(flushCondition["when"].(string)),
-			"conditional": conditional,
-		})
+		whenValue := flushCondition["when"].(string)
+		if whenValue == "starts_when" || whenValue == "ends_when" {
+			conditional := unwindConditionalToModel(flushCondition["conditional"].(map[string]any))
+			plan.FlushCondition = NewObjectValueMust(map[string]attr.Type{
+				"when":        StringType{},
+				"conditional": conditional.Type(context.Background()),
+			}, map[string]attr.Value{
+				"when":        NewStringValue(whenValue),
+				"conditional": conditional,
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
The flush_condition block will always appear in the API response but should be ignored/disabled if the `when` child attribute is set to `none`. This commit corrects this logic by only attempting to parse the block for valid `when` values.

Ref: LOG-18549