### PR TITLE
feat(import): Implement state import for all pipeline resources

### DIFF
--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"os"
 	"reflect"
 	"strings"
@@ -229,4 +230,40 @@ func (r *DestinationResource[T]) Update(ctx context.Context, req resource.Update
 // Schema implements resource.Resource.
 func (r *DestinationResource[T]) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = r.schema
+}
+
+func (r *DestinationResource[T]) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.Split(req.ID, "/")
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError(
+			"Malformed Resource Import Id",
+			fmt.Sprintf(
+				"The destination resource import id needs to be in the form of <pipeline id>/<destination id>. The "+
+					"input \"%s\" did not contain two parts after parsing the id.",
+				req.ID,
+			),
+		)
+		return
+	}
+
+	pipelineId := strings.TrimSpace(parts[0])
+	if pipelineId == "" {
+		resp.Diagnostics.AddError(
+			"Resource Import Id Missing Pipeline Id Part",
+			"The pipeline id specified only contained whitespace.",
+		)
+	}
+
+	nodeId := strings.TrimSpace(parts[1])
+	if nodeId == "" {
+		resp.Diagnostics.AddError(
+			"Resource Import Id Missing Destination Id Part",
+			"The destination id specified only contained whitespace",
+		)
+	}
+
+	if !resp.Diagnostics.HasError() {
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), nodeId)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("pipeline_id"), pipelineId)...)
+	}
 }

--- a/internal/provider/models/destinations/test/azure_blob_storage_test.go
+++ b/internal/provider/models/destinations/test/azure_blob_storage_test.go
@@ -72,6 +72,23 @@ func TestAzureBlobStorageDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_azure_blob_storage_destination" "import_target" {
+						title             = "My destination"
+						description       = "my destination description"
+						inputs            = [mezmo_http_source.my_source.id]
+						pipeline_id       = mezmo_pipeline.test_parent.id
+						connection_string = "abc://defg.com"
+						container_name    = "my_container"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_azure_blob_storage_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_azure_blob_storage_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/blackhole_test.go
+++ b/internal/provider/models/destinations/test/blackhole_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBlackholeDestinationResource(t *testing.T) {
+	const cacheKey = "blackhole_destination_resource"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { TestPreCheck(t) },
@@ -21,10 +22,10 @@ func TestBlackholeDestinationResource(t *testing.T) {
 			},
 			// Create and Read testing
 			{
-				Config: GetProviderConfig() + `
+				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
 						title = "parent pipeline"
-					}
+					}`) + `
 					resource "mezmo_blackhole_destination" "my_destination" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "my destination title"
@@ -41,6 +42,19 @@ func TestBlackholeDestinationResource(t *testing.T) {
 						"inputs.#":      "0",
 					}),
 				),
+			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_blackhole_destination" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my destination title"
+						description = "my destination description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_blackhole_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_blackhole_destination.my_destination"),
+				ImportStateVerify: true,
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/models/destinations/test/datadog_logs_test.go
+++ b/internal/provider/models/destinations/test/datadog_logs_test.go
@@ -116,6 +116,23 @@ func TestDatadogLogsDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_datadog_logs_destination" "import_target" {
+						title       = "my logs destination"
+						description = "logs description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						site        = "us3"
+						api_key     = "<secret-api-key>"
+						compression = "gzip"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_datadog_logs_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_datadog_logs_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/datadog_metrics_test.go
+++ b/internal/provider/models/destinations/test/datadog_metrics_test.go
@@ -92,6 +92,22 @@ func TestDatadogMetricsDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_datadog_metrics_destination" "import_target" {
+						title       = "my metrics destination"
+						description = "metrics description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						site        = "us3"
+						api_key     = "<secret-api-key>"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_datadog_metrics_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_datadog_metrics_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/elasticsearch_test.go
+++ b/internal/provider/models/destinations/test/elasticsearch_test.go
@@ -101,6 +101,27 @@ func TestElasticSearchDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_elasticsearch_destination" "import_target" {
+						title = "My destination"
+						description = "my destination description"
+						inputs      = [mezmo_http_source.my_source.id]
+						pipeline_id = mezmo_pipeline.test_parent.id
+						endpoints   = ["https://google.com"]
+						auth = {
+							strategy = "basic"
+							user     = "user1"
+							password = "pass1"
+						}
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_elasticsearch_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_elasticsearch_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields (pass through)
 			{
 				Config: SetCachedConfig(cacheKey, `

--- a/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
@@ -186,6 +186,28 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_gcp_cloud_storage_destination" "import_target" {
+						title = "test dest"
+						description = "test dest description"
+						inputs = [mezmo_http_source.test_source.id]
+						pipeline_id = mezmo_pipeline.test_parent.id
+						encoding = "json"
+						compression = "gzip"
+						bucket = "test_bucket"
+						bucket_prefix = "bucket_prefix"
+						auth = {
+							type = "api_key"
+							value = "key"
+						}
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_gcp_cloud_storage_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_gcp_cloud_storage_destination.my_dest"),
+				ImportStateVerify: true,
+			},
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/honeycomb_logs_test.go
+++ b/internal/provider/models/destinations/test/honeycomb_logs_test.go
@@ -77,6 +77,22 @@ func TestHoneycombLogsDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_honeycomb_logs_destination" "import_target" {
+						title = "My destination"
+						description = "my destination description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						dataset     = "ds1"
+						api_key     = "key1"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_honeycomb_logs_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_honeycomb_logs_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/http_test.go
+++ b/internal/provider/models/destinations/test/http_test.go
@@ -94,6 +94,21 @@ func TestHttpDestination(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_http_destination" "import_target" {
+						title = "my http destination"
+						description = "http destination description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						uri = "http://example.com"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_http_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_http_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/kafka_test.go
+++ b/internal/provider/models/destinations/test/kafka_test.go
@@ -345,6 +345,28 @@ func TestKafkaDestinationResource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_kafka_destination" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my kafka title"
+						description = "my kafka description"
+						brokers = [{
+						    host = "mezmo.com"
+						    port = 9092
+						}]
+						event_key_field = "my_key"
+						topic = "topic1"
+						compression = "gzip"
+						encoding = "json"
+						ack_enabled = true
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_kafka_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_kafka_destination.my_destination"),
+				ImportStateVerify: true,
+			},
 			// Update and Read with new broker testing
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/loki_test.go
+++ b/internal/provider/models/destinations/test/loki_test.go
@@ -62,6 +62,31 @@ func TestLokiDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_loki_destination" "import_target" {
+						title = "test destination"
+						description = "loki destination"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						auth = {
+							strategy = "basic"
+							user     = "username"
+							password = "secret-password"
+						}
+						endpoint = "http://example.com"
+						encoding = "json"
+						labels = {
+							"test_key_0" = "test_value_0"
+							"test_key_1" = "test_value_1"
+						}
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_loki_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_loki_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Required field encoding
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/mezmo_test.go
+++ b/internal/provider/models/destinations/test/mezmo_test.go
@@ -69,6 +69,21 @@ func TestMezmoDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_logs_destination" "import_target" {
+						title = "My destination"
+						description = "my destination description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						ingestion_key = "my_key"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_logs_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_logs_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields (pass through)
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/new_relic_test.go
+++ b/internal/provider/models/destinations/test/new_relic_test.go
@@ -79,6 +79,23 @@ func TestNewRelicDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_new_relic_destination" "import_target" {
+						title = "My destination"
+						description = "my destination description"
+						inputs      = [mezmo_http_source.my_source.id]
+						pipeline_id = mezmo_pipeline.test_parent.id
+						account_id = "acc1"
+						license_key = "key1"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_new_relic_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_new_relic_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields (pass through)
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/destinations/test/prometheus_remote_write_test.go
@@ -115,6 +115,22 @@ func TestPrometheusDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_prometheus_remote_write_destination" "import_target" {
+						title = "My destination"
+						description = "my destination description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						inputs = [mezmo_http_source.my_source.id]
+						endpoint = "https://google.com"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_prometheus_remote_write_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_prometheus_remote_write_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/s3_test.go
+++ b/internal/provider/models/destinations/test/s3_test.go
@@ -108,6 +108,26 @@ func TestS3DestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_s3_destination" "import_target" {
+						title       = "My destination"
+						description = "my destination description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						region      = "us-west1"
+						auth = {
+							access_key_id = "my_key"
+							secret_access_key = "my_secret"
+						}
+						bucket = "mybucket"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_s3_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_s3_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update all fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/destinations/test/splunk_hec_logs_test.go
+++ b/internal/provider/models/destinations/test/splunk_hec_logs_test.go
@@ -103,6 +103,22 @@ func TestSplunkHecLogsDestinationResource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_splunk_hec_logs_destination" "import_target" {
+						title = "My destination"
+						description = "my destination description"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						endpoint    = "https://google.com"
+						token       = "my_token"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_splunk_hec_logs_destination.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_splunk_hec_logs_destination.my_destination"),
+				ImportStateVerify: true,
+			},
+
 			// Update source fields and others
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/compact_fields_test.go
+++ b/internal/provider/models/processors/test/compact_fields_test.go
@@ -86,6 +86,21 @@ func TestCompactFieldsProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_compact_fields_processor" "import_target" {
+						title = "compact fields title"
+						description = "compact fields desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						fields = [".thing1", ".thing2"]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_compact_fields_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_compact_fields_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/decrypt_fields_test.go
+++ b/internal/provider/models/processors/test/decrypt_fields_test.go
@@ -159,6 +159,24 @@ func TestDecryptFieldsProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_decrypt_fields_processor" "import_target" {
+						title = "decrypt fields title"
+						description = "decrypt fields desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						algorithm = "AES-128-CFB"
+						key = "1111111111111111"
+						iv_field = ".some_iv_field"
+						field = ".something"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_decrypt_fields_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_decrypt_fields_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/dedupe_test.go
+++ b/internal/provider/models/processors/test/dedupe_test.go
@@ -86,6 +86,21 @@ func TestDedupeProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_dedupe_processor" "import_target" {
+						title = "dedupe title"
+						description = "dedupe desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						fields = [".thing1", ".thing2"]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_dedupe_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_dedupe_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/drop_fields_test.go
+++ b/internal/provider/models/processors/test/drop_fields_test.go
@@ -84,6 +84,21 @@ func TestDropFieldsProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_drop_fields_processor" "import_target" {
+						title = "processor title"
+						description = "processor desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						fields = [".thing1", ".thing2"]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_drop_fields_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_drop_fields_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/encrypt_fields_test.go
+++ b/internal/provider/models/processors/test/encrypt_fields_test.go
@@ -159,6 +159,24 @@ func TestEncryptFieldsProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_encrypt_fields_processor" "import_target" {
+						title = "encrypt fields title"
+						description = "encrypt fields desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						algorithm = "AES-128-CFB"
+						key = "1111111111111111"
+						iv_field = ".some_iv_field"
+						field = ".something"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_encrypt_fields_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_encrypt_fields_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/event_to_metric_test.go
+++ b/internal/provider/models/processors/test/event_to_metric_test.go
@@ -241,6 +241,25 @@ func TestEventToMetricProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_event_to_metric_processor" "import_target" {
+						title = "title"
+						description = "desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						metric_name = "my_metric"
+						metric_type = "counter"
+						metric_kind = "absolute"
+						namespace_field = ".namespace"
+						value_field = ".something"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_event_to_metric_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_event_to_metric_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/filter_test.go
+++ b/internal/provider/models/processors/test/filter_test.go
@@ -167,6 +167,32 @@ func TestFilterProcessor(t *testing.T) {
 					}),
 				),
 			},
+
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_filter_processor" "import_target" {
+				title = "processor title"
+						description = "processor desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						inputs = [mezmo_http_source.my_source.id]
+						action = "allow"
+						conditional = {
+							expressions = [
+								{
+									field = ".status"
+									operator = "equal"
+									value_number = 200
+								}
+							]
+						}
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_filter_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_filter_processor.single_expression"),
+				ImportStateVerify: true,
+			},
+
 			// Complex expression
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/flatten_fields_test.go
+++ b/internal/provider/models/processors/test/flatten_fields_test.go
@@ -65,6 +65,20 @@ func TestFlattenFieldsProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_flatten_fields_processor" "import_target" {
+						title = "flatten fields title"
+						description = "flatten fields desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_flatten_fields_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_flatten_fields_processor.my_processor_defaults"),
+				ImportStateVerify: true,
+			},
+
 			// Create with fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/map_fields_test.go
+++ b/internal/provider/models/processors/test/map_fields_test.go
@@ -112,6 +112,28 @@ func TestMapFieldsProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_map_fields_processor" "import_target" {
+						title = "some title"
+						description = "some description"
+						inputs = [mezmo_http_source.my_source.id]
+						pipeline_id = mezmo_pipeline.test_parent.id
+
+						mappings = [
+							{
+								source_field = ".field1"
+								target_field = ".field2"
+							},
+						]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_map_fields_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_map_fields_processor.single_mapping"),
+				ImportStateVerify: true,
+			},
+
 			// Multiple mappings
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/metrics_tag_cardinality_limit_test.go
+++ b/internal/provider/models/processors/test/metrics_tag_cardinality_limit_test.go
@@ -146,6 +146,21 @@ func TestMetricsTagCardinalityLimitProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_metrics_tag_cardinality_limit_processor" "import_target" {
+						title = "title"
+						description = "desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						value_limit = 50
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_metrics_tag_cardinality_limit_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_metrics_tag_cardinality_limit_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/parse_sequentially_test.go
+++ b/internal/provider/models/processors/test/parse_sequentially_test.go
@@ -487,6 +487,30 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 					}),
 				),
 			},
+
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_sequentially_processor" "import_target" {
+						title = "custom csv parser title"
+						description = "custom csv parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						parsers = [
+							{
+								parser = "csv_row"
+								csv_row_options = {
+									field_names = ["field1", "field2"]
+								}
+							}
+						]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_parse_sequentially_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_parse_sequentially_processor.csv_parser"),
+				ImportStateVerify: true,
+			},
+
 			// Create multiple parsers
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/parse_test.go
+++ b/internal/provider/models/processors/test/parse_test.go
@@ -430,6 +430,27 @@ func TestParseProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_processor" "import_target" {
+						title = "custom apache parser title"
+						description = "custom apache parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						parser = "apache_log"
+						apache_log_options = {
+							format = "common"
+							timestamp_format = "Custom"
+							custom_timestamp_format = "%Y/%m/%d %H:%M:%S"
+						}
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_parse_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_parse_processor.apache_custom_time"),
+				ImportStateVerify: true,
+			},
+
 			// Update apache parser with custom timestamp to nginx
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/reduce_test.go
+++ b/internal/provider/models/processors/test/reduce_test.go
@@ -108,6 +108,20 @@ func TestReduceProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_reduce_processor" "import_target" {
+						title = "processor title"
+						description = "processor desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_reduce_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_reduce_processor.default_values"),
+				ImportStateVerify: true,
+			},
+
 			// Add options
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/route_test.go
+++ b/internal/provider/models/processors/test/route_test.go
@@ -164,6 +164,34 @@ func TestRouteProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_route_processor" "import_target" {
+						title = "processor title"
+						description = "processor desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						inputs = [mezmo_http_source.my_source.id]
+
+						conditionals = [
+							{
+								expressions = [
+									{
+										field = ".status"
+										operator = "equal"
+										value_number = 200
+									}
+								]
+								label = "success logs"
+							}
+						]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_route_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_route_processor.single_expression"),
+				ImportStateVerify: true,
+			},
+
 			// Nested expression
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/sample_test.go
+++ b/internal/provider/models/processors/test/sample_test.go
@@ -77,6 +77,20 @@ func TestSampleProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_sample_processor" "import_target" {
+						title = "test title"
+						description = "test desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_sample_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_sample_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update fields: always_include w/ no value
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/script_execution_test.go
+++ b/internal/provider/models/processors/test/script_execution_test.go
@@ -72,6 +72,21 @@ func TestScriptExecutionProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_script_execution_processor" "import_target" {
+						title = "processor title"
+						description = "processor desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						script = "function processEvent(e) { return e }"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_script_execution_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_script_execution_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/stringify_test.go
+++ b/internal/provider/models/processors/test/stringify_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestStringifyProcessorResource(t *testing.T) {
+	const cacheKey = "stringify_processor_resource"
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		PreCheck:                 func() { TestPreCheck(t) },
@@ -21,10 +22,10 @@ func TestStringifyProcessorResource(t *testing.T) {
 			},
 			// Create and Read testing
 			{
-				Config: GetProviderConfig() + `
+				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
 						title = "parent pipeline"
-					}
+					}`) + `
 					resource "mezmo_stringify_processor" "my_processor" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "my stringify title"
@@ -40,6 +41,19 @@ func TestStringifyProcessorResource(t *testing.T) {
 						"inputs.#":      "0",
 					}),
 				),
+			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_stringify_processor" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my stringify title"
+						description = "my stringify description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_stringify_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_stringify_processor.my_processor"),
+				ImportStateVerify: true,
 			},
 			// Update and Read testing
 			{

--- a/internal/provider/models/processors/test/unroll_test.go
+++ b/internal/provider/models/processors/test/unroll_test.go
@@ -73,6 +73,21 @@ func TestUnrollProcessor(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_unroll_processor" "import_target" {
+						title = "processor title"
+						description = "processor desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".thing1"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_unroll_processor.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_unroll_processor.my_processor"),
+				ImportStateVerify: true,
+			},
+
 			// Update
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/agent_test.go
+++ b/internal/provider/models/sources/test/agent_test.go
@@ -66,6 +66,20 @@ func TestAgentSourceResource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_agent_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "bad new title"
+						description = "new description"
+						capture_metadata = "true"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_agent_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_agent_source.my_source"),
+				ImportStateVerify: true,
+			},
 			// Supply gateway_route_id
 			{
 				Config: SetCachedConfig(cacheKey, `

--- a/internal/provider/models/sources/test/azure_event_hub_test.go
+++ b/internal/provider/models/sources/test/azure_event_hub_test.go
@@ -197,6 +197,22 @@ func TestAzureEventHubSourceResource(t *testing.T) {
 			},
 			{
 				Config: providertest.GetCachedConfig(cacheKey) + `
+					resource "mezmo_azure_event_hub_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "test title"
+						description = "test description"
+						connection_string = "test_connection_string"
+						namespace = "test_namespace"
+						group_id = "test_group_id"
+						topics = ["topic1", "topic2"]
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_azure_event_hub_source.import_target",
+				ImportStateIdFunc: providertest.ComputeImportId("mezmo_azure_event_hub_source.my_source"),
+				ImportStateVerify: true,
+			},
+			{
+				Config: providertest.GetCachedConfig(cacheKey) + `
 					resource "mezmo_azure_event_hub_source" "my_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "new title"

--- a/internal/provider/models/sources/test/datadog_test.go
+++ b/internal/provider/models/sources/test/datadog_test.go
@@ -46,6 +46,20 @@ func TestDatadogSource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_datadog_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						description = "my description"
+						title = "my title"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_datadog_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_datadog_source.my_source"),
+				ImportStateVerify: true,
+			},
+
 			// Updates
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/fluent_test.go
+++ b/internal/provider/models/sources/test/fluent_test.go
@@ -58,6 +58,20 @@ func TestFluentSource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_fluent_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my title"
+						description = "my description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_fluent_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_fluent_source.my_source"),
+				ImportStateVerify: true,
+			},
+
 			// Update and Read testing
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/http_test.go
+++ b/internal/provider/models/sources/test/http_test.go
@@ -55,6 +55,19 @@ func TestHttpSource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_http_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my http title"
+						description = "my http description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_http_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_http_source.my_source"),
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/kafka_test.go
+++ b/internal/provider/models/sources/test/kafka_test.go
@@ -380,6 +380,26 @@ func TestKafkaSourceResource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_kafka_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my kafka title"
+						description = "my kafka description"
+						brokers = [{
+						    host = "mezmo.com"
+						    port = 9092
+						}]
+						topics = ["topic1", "topic2"]
+						group_id = "my_group_id"
+						tls_enabled = true
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_kafka_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_kafka_source.my_source"),
+				ImportStateVerify: true,
+			},
 			// Update and Read with new broker testing
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/kinesis_firehose_test.go
+++ b/internal/provider/models/sources/test/kinesis_firehose_test.go
@@ -57,6 +57,21 @@ func TestKinesisFirehoseSourceResource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: providertest.GetCachedConfig(cacheKey) + `
+					resource "mezmo_kinesis_firehose_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "test title"
+						description = "test description"
+						decoding = "text"
+						capture_metadata = true
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_kinesis_firehose_source.import_target",
+				ImportStateIdFunc: providertest.ComputeImportId("mezmo_kinesis_firehose_source.my_source"),
+				ImportStateVerify: true,
+			},
 			{
 				Config: providertest.GetCachedConfig(cacheKey) + `
 					resource "mezmo_kinesis_firehose_source" "my_source" {

--- a/internal/provider/models/sources/test/log_analysis_test.go
+++ b/internal/provider/models/sources/test/log_analysis_test.go
@@ -48,6 +48,19 @@ func TestLogAnalysisSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet("mezmo_log_analysis_source.my_source", "generation_id"),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_log_analysis_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my source title"
+						description = "my source description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_log_analysis_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_log_analysis_source.my_source"),
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: GetProviderConfig() + `

--- a/internal/provider/models/sources/test/logstash_test.go
+++ b/internal/provider/models/sources/test/logstash_test.go
@@ -55,6 +55,21 @@ func TestLogStashSource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_logstash_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "bad new title"
+						description = "new description"
+						capture_metadata = "true"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_logstash_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_logstash_source.my_source"),
+				ImportStateVerify: true,
+			},
+
 			// Updates
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/sources/test/prometheus_remote_write_test.go
@@ -51,6 +51,19 @@ func TestPrometheusRemoteWriteSource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_prometheus_remote_write_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my prometheus remote write title"
+						description = "my prometheus remote write description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_prometheus_remote_write_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_prometheus_remote_write_source.my_source"),
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/splunk_hec_test.go
+++ b/internal/provider/models/sources/test/splunk_hec_test.go
@@ -47,6 +47,19 @@ func TestSplunkHecSource(t *testing.T) {
 					}),
 				),
 			},
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_splunk_hec_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						title = "my title"
+						description = "my description"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_splunk_hec_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_splunk_hec_source.my_source"),
+				ImportStateVerify: true,
+			},
 			// Update and Read testing
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/sqs_test.go
+++ b/internal/provider/models/sources/test/sqs_test.go
@@ -120,6 +120,26 @@ func TestSQSSource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_sqs_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						description = "my description"
+						title = "my title"
+						queue_url = "http://example.com/queue"
+						region = "us-east-2"
+						auth = {
+							access_key_id = "123"
+							secret_access_key = "secret123"
+						}
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_sqs_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_sqs_source.my_source"),
+				ImportStateVerify: true,
+			},
+
 			// Updates
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/sources/test/webhook_test.go
+++ b/internal/provider/models/sources/test/webhook_test.go
@@ -66,6 +66,21 @@ func TestWebhookSource(t *testing.T) {
 				),
 			},
 
+			// Import
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_webhook_source" "import_target" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						description = "my description"
+						title = "my title"
+						signing_key = "sshhh"
+					}`,
+				ImportState:       true,
+				ResourceName:      "mezmo_webhook_source.import_target",
+				ImportStateIdFunc: ComputeImportId("mezmo_webhook_source.my_source"),
+				ImportStateVerify: true,
+			},
+
 			// Updates
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -15,8 +16,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = &PipelineResource{}
-	_ resource.ResourceWithConfigure = &PipelineResource{}
+	_ resource.Resource                = &PipelineResource{}
+	_ resource.ResourceWithConfigure   = &PipelineResource{}
+	_ resource.ResourceWithImportState = &PipelineResource{}
 )
 
 func NewPipelineResource() resource.Resource {
@@ -182,4 +184,8 @@ func (r *PipelineResource) Update(ctx context.Context, req resource.UpdateReques
 func setDiagnosticsHasError(source diag.Diagnostics, target *diag.Diagnostics) bool {
 	target.Append(source...)
 	return target.HasError()
+}
+
+func (r *PipelineResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/providertest/utils.go
+++ b/internal/provider/providertest/utils.go
@@ -156,3 +156,17 @@ func StateHasExpectedValues(resourceName string, expected map[string]any) resour
 		return nil
 	}
 }
+
+func ComputeImportId(resourceName string) resource.ImportStateIdFunc {
+	return func(state *terraform.State) (string, error) {
+		resource := state.RootModule().Resources[resourceName]
+		if resource == nil {
+			return "", fmt.Errorf("resource \"%s\" not found", resourceName)
+		}
+		attributes := resource.Primary.Attributes
+		if pipelineId, ok := attributes["pipeline_id"]; ok {
+			return fmt.Sprintf("%s/%s", pipelineId, resource.Primary.ID), nil
+		}
+		return "", fmt.Errorf("resource \"%s\" does not have an attribute \"pipeline_id\"", resourceName)
+	}
+}


### PR DESCRIPTION
This commit implements `terraform import` for all piepline resources. This now allows rebuilding the state of an existing pipeline so a user can start to manage existing pipelines with terraform instead of the UI.

Ref: LOG-18134