### PR TITLE
fix: Update parse and sequential parse proccessors to accept new options

### DIFF
--- a/docs/resources/parse_processor.md
+++ b/docs/resources/parse_processor.md
@@ -107,6 +107,13 @@ Required:
 
 - `pattern` (String) The regex pattern.
 
+Optional:
+
+- `case_sensitive` (Boolean) Perform case sensitive regex matching
+- `crlf_newline` (Boolean) When true and multiline = true, newline character will be interpreted as
+- `match_newline` (Boolean) When true, dot (.) will match newline characters
+- `multiline` (Boolean) When true, ^ and $ will match not only the beginning and end of a string but also the start and end of lines
+
 
 <a id="nestedatt--timestamp_parser_options"></a>
 ### Nested Schema for `timestamp_parser_options`

--- a/docs/resources/parse_sequentially_processor.md
+++ b/docs/resources/parse_sequentially_processor.md
@@ -122,6 +122,13 @@ Required:
 
 - `pattern` (String) The regex pattern.
 
+Optional:
+
+- `case_sensitive` (Boolean) Perform case sensitive regex matching
+- `crlf_newline` (Boolean) When true and multiline = true, newline character will be interpreted as
+- `match_newline` (Boolean) When true, dot (.) will match newline characters
+- `multiline` (Boolean) When true, ^ and $ will match not only the beginning and end of a string but also the start and end of lines
+
 
 <a id="nestedatt--parsers--timestamp_parser_options"></a>
 ### Nested Schema for `parsers.timestamp_parser_options`

--- a/examples/processors/parse.tf
+++ b/examples/processors/parse.tf
@@ -56,6 +56,7 @@ resource "mezmo_parse_processor" "regex" {
   field       = ".log"
   parser      = "regex_parser"
   regex_parser_options = {
-    pattern = "^(?P<number>[0-9]*)(?P<word>\\w*)(?P<singlequote>\\')(?P<slash>\\\\?)"
+    pattern        = "^(?P<number>[0-9]*)(?P<word>\\w*)(?P<singlequote>\\')(?P<slash>\\\\?)"
+    case_sensitive = false
   }
 }

--- a/examples/processors/parse_sequentially.tf
+++ b/examples/processors/parse_sequentially.tf
@@ -49,6 +49,14 @@ resource "mezmo_parse_sequentially_processor" "processor1" {
       csv_parser_options = {
         field_names = ["field_1", "field_2"]
       }
+    },
+    {
+      parser = "regex_parser"
+      regex_parser_options = {
+        pattern        = "\\d{3}-\\d{2}-\\d{3}"
+        case_sensitive = false
+        multiline      = true
+      }
     }
   ]
 }

--- a/internal/provider/models/processors/base_parse_model.go
+++ b/internal/provider/models/processors/base_parse_model.go
@@ -144,6 +144,26 @@ var base_options_parser_schema = SchemaAttributes{
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
+			"case_sensitive": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "Perform case sensitive regex matching",
+			},
+			"multiline": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When true, ^ and $ will match not only the beginning and end of a string but also the start and end of lines",
+			},
+			"match_newline": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When true, dot (.) will match newline characters",
+			},
+			"crlf_newline": schema.BoolAttribute{
+				Optional:    true,
+				Computed:    true,
+				Description: "When true and multiline = true, newline character will be interpreted as \r\n",
+			},
 		},
 	},
 	"timestamp_parser_options": schema.SingleNestedAttribute{

--- a/internal/provider/models/processors/parse.go
+++ b/internal/provider/models/processors/parse.go
@@ -188,7 +188,20 @@ func optionsToModel(parser string, options map[string]any) basetypes.ObjectValue
 		return basetypes.NewObjectNull(nil)
 	}
 
-	values := MapAnyFillMissingValues(attr_types, options, optional_fields)
+	// strip any new options we don't know about in Terraform world
+	attr_type_keys := append(MapKeys(attr_types), optional_fields...)
+
+	values := MapAnyFillMissingValues(attr_types, StripUnknownOptions(attr_type_keys, options), optional_fields)
 	new_options := basetypes.NewObjectValueMust(attr_types, values)
+	return new_options
+}
+
+func StripUnknownOptions(attr_type_keys []string, options map[string]any) map[string]any {
+	new_options := make(map[string]any)
+	for _, k := range attr_type_keys {
+		if v, ok := options[k]; ok {
+			new_options[k] = v
+		}
+	}
 	return new_options
 }

--- a/internal/provider/models/processors/parse_sequentially.go
+++ b/internal/provider/models/processors/parse_sequentially.go
@@ -208,7 +208,8 @@ func parserItemToModel(api_parser_item map[string]any) map[string]attr.Value {
 		if !ok {
 			optional_fields = []string{}
 		}
-		values := MapAnyFillMissingValues(attr_types, api_options, optional_fields)
+		attr_type_keys := append(MapKeys(attr_types), optional_fields...)
+		values := MapAnyFillMissingValues(attr_types, StripUnknownOptions(attr_type_keys, api_options), optional_fields)
 		parser_item[options_key] = basetypes.NewObjectValueMust(attr_types, values)
 	}
 

--- a/internal/provider/models/processors/test/parse_test.go
+++ b/internal/provider/models/processors/test/parse_test.go
@@ -366,6 +366,74 @@ func TestParseProcessor(t *testing.T) {
 					}),
 				),
 			},
+			// regex parser with default options
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_processor" "regex_defaults" {
+						title = "regex parser title"
+						description = "regex parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						parser = "regex_parser"
+						regex_parser_options = {
+							pattern = "\\d{3}-\\d{2}-\\d{3}"
+						}
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_parse_processor.regex_defaults", "id", regexp.MustCompile(`[\w-]{36}`)),
+
+					StateHasExpectedValues("mezmo_parse_processor.regex_defaults", map[string]any{
+						"pipeline_id":                         "#mezmo_pipeline.test_parent.id",
+						"title":                               "regex parser title",
+						"description":                         "regex parser desc",
+						"generation_id":                       "0",
+						"inputs.#":                            "0",
+						"field":                               ".something",
+						"parser":                              "regex_parser",
+						"regex_parser_options.pattern":        "\\d{3}-\\d{2}-\\d{3}",
+						"regex_parser_options.case_sensitive": "true",
+						"regex_parser_options.multiline":      "false",
+						"regex_parser_options.match_newline":  "false",
+						"regex_parser_options.crlf_newline":   "false",
+					}),
+				),
+			},
+			// regex parser with custom options
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_processor" "regex_custom" {
+						title = "regex parser title"
+						description = "regex parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						parser = "regex_parser"
+						regex_parser_options = {
+							pattern = "\\d{3}-\\d{2}-\\d{3}"
+							case_sensitive = false
+							multiline = true
+						}
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_parse_processor.regex_custom", "id", regexp.MustCompile(`[\w-]{36}`)),
+
+					StateHasExpectedValues("mezmo_parse_processor.regex_custom", map[string]any{
+						"pipeline_id":                         "#mezmo_pipeline.test_parent.id",
+						"title":                               "regex parser title",
+						"description":                         "regex parser desc",
+						"generation_id":                       "0",
+						"inputs.#":                            "0",
+						"field":                               ".something",
+						"parser":                              "regex_parser",
+						"regex_parser_options.pattern":        "\\d{3}-\\d{2}-\\d{3}",
+						"regex_parser_options.case_sensitive": "false",
+						"regex_parser_options.multiline":      "true",
+						"regex_parser_options.match_newline":  "false",
+						"regex_parser_options.crlf_newline":   "false",
+					}),
+				),
+			},
 			// Create apache parser with default timestamp
 			{
 				Config: GetCachedConfig(cacheKey) + `


### PR DESCRIPTION
New regex options were added to the API which broke CI with parse and sequential parse processors failing in tests. Four of the 5 new options have been added to the regex parser. A new function has also been added to exclude options we do not yet know about in Terraform.

Ref: LOG-18741