### PR TITLE
LOG-18743: squelch `dev_overrides` warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ examples/%.tf: build-test-example-binary
 		-e TF_CLI_CONFIG_FILE=/opt/app/tf-dev-config \
 		-w /opt/example/ \
 		hashicorp/terraform:latest \
-		validate
+		validate -compact-warnings | \
+		awk '/Provider development overrides are in effect/ {next} {print}'
 
 .PHONY: local-test
 ENV := $(PWD)/env/local.env


### PR DESCRIPTION
When using the `dev_overrides` block in terraform config, there is a warning that crops up everytime you run terraform. This removes that warning.

ref: LOG-18743