### PR TITLE
fix(operators):  Add not_contains to list of operators

### DIFF
--- a/internal/provider/models/modelutils/operator_labels.go
+++ b/internal/provider/models/modelutils/operator_labels.go
@@ -18,6 +18,7 @@ var Operators = []string{
 	"is_string",
 	"less",
 	"less_or_equal",
+	"not_contains",
 	"not_equal",
 	"not_exists",
 	"not_regex_match",


### PR DESCRIPTION
We added support for a new not_contains operator in the service. This adds supports in the terraform provider.

Ref: LOG-18791