### PR TITLE
fix: non empty string field serialization

### DIFF
--- a/internal/provider/models/processors/test/parse_sequentially_test.go
+++ b/internal/provider/models/processors/test/parse_sequentially_test.go
@@ -787,6 +787,26 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 					}),
 				),
 			},
+			// user_options correctly serialized
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_sequentially_processor" "parse_processor_with_user_options" {
+						title = "create parsers title"
+						description = "create parsers desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						inputs = [mezmo_http_source.my_source.id]
+						field = ".app"
+						parsers = [
+							{
+								parser = "key_value_log"
+								key_value_log_options = {
+									key_value_delimiter = "@"
+								}
+							}
+						]
+					}`,
+				Check: resource.TestMatchResourceAttr("mezmo_parse_sequentially_processor.parse_processor_with_user_options", "id", regexp.MustCompile(`[\w-]{36}`)),
+			},
 			// Server side validation on create
 			{
 				Config: GetCachedConfig(cacheKey) + `

--- a/internal/provider/models/processors/test/parse_sequentially_test.go
+++ b/internal/provider/models/processors/test/parse_sequentially_test.go
@@ -587,7 +587,7 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 									pattern = "\\d{3}-\\d{2}-\\d{3}"
 									multiline = true
 									case_sensitive = false
-									match_newline = true 
+									match_newline = true
 									crlf_newline = true
 								}
 							}

--- a/internal/provider/models/processors/test/parse_test.go
+++ b/internal/provider/models/processors/test/parse_test.go
@@ -628,6 +628,21 @@ func TestParseProcessor(t *testing.T) {
 					}),
 				),
 			},
+			// user_options correctly serialized
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_processor" "parse_processor_with_user_options" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+						inputs = [mezmo_http_source.my_source.id]
+						title       = "2-parser"
+						field       = ".user.email"
+						parser      = "key_value_log"
+						key_value_log_options = {
+							key_value_delimiter = "@"
+						}
+					}`,
+				Check: resource.TestMatchResourceAttr("mezmo_parse_processor.parse_processor_with_user_options", "id", regexp.MustCompile(`[\w-]{36}`)),
+			},
 			// Server side validation on create
 			{
 				Config: GetCachedConfig(cacheKey) + `


### PR DESCRIPTION
Terraform was sending the an invalid request similar to the following when either of the delimiter options for the `parse_key_value` parser were unset.

```json
{
    "generation_id": 0,
    "inputs": [
        "3bbfe394-946c-11ee-893f-0242ac170004"
    ],
    "title": "2-parser",
    "type": "parse",
    "user_config": {
        "field": ".user.email",
        "options": {
            "field_delimiter": "",
            "key_value_delimiter": "@"
        },
        "parser": "parse_key_value",
        "target_field": ""
    }
}
```

Note `field_delimiter": ""` defaults to an empty string, which pipeline-service rejects as the delimiter must have a length of at least 1.

The problem seems to be in our internal model types and their interaction with go’s serialization magic. When constructing a Model we call the `MapAndFillMissingValues` function to populate any missing optional values including `map[string]string`s which are populated with terraform’s `StringNull` type. The `StringNull` type seems to defeat Go’s built in `json.Marshal`'s `omitempty` annotation.

This PR adds some custom serialization logic for the offending fields so that they're serialized as if they were `nil` rather than forcibly populating them as empty strings.