### PR TITLE
fix: Remove validation on  parse target_field

### DIFF
--- a/internal/provider/models/processors/base_parse_model.go
+++ b/internal/provider/models/processors/base_parse_model.go
@@ -200,9 +200,6 @@ var base_schema = SchemaAttributes{
 		Computed: true,
 		Description: "The field into which the parsed value should be inserted. Leave blank to " +
 			"insert the parsed data into the original field.",
-		Validators: []validator.String{
-			stringvalidator.LengthAtLeast(1),
-		},
 	},
 }
 

--- a/internal/provider/models/processors/test/parse_sequentially_test.go
+++ b/internal/provider/models/processors/test/parse_sequentially_test.go
@@ -450,6 +450,88 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 				ExpectError: regexp.MustCompile(`(?s)Attribute parsers\[0\].timestamp_parser_options.custom_format string length.*must be at least 1, got: 0`),
 			},
 
+			// parser with empty target
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_sequentially_processor" "with_empty_target" {
+						title = "custom regex parser title"
+						description = "custom regex parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						target_field = ""
+						parsers = [
+							{
+								parser = "regex_parser"
+								regex_parser_options = {
+									pattern = "\\d{3}-\\d{2}-\\d{3}"
+								}
+							}
+						]
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_parse_sequentially_processor.with_empty_target", "id", regexp.MustCompile(`[\w-]{36}`)),
+
+					StateHasExpectedValues("mezmo_parse_sequentially_processor.with_empty_target", map[string]any{
+						"pipeline_id":                            "#mezmo_pipeline.test_parent.id",
+						"title":                                  "custom regex parser title",
+						"description":                            "custom regex parser desc",
+						"generation_id":                          "0",
+						"inputs.#":                               "0",
+						"field":                                  ".something",
+						"target_field":                           "",
+						"parsers.#":                              "1",
+						"parsers.0.parser":                       "regex_parser",
+						"parsers.0.regex_parser_options.pattern": "\\d{3}-\\d{2}-\\d{3}",
+						"parsers.0.regex_parser_options.case_sensitive": "true",
+						"parsers.0.regex_parser_options.multiline":      "false",
+						"parsers.0.regex_parser_options.match_newline":  "false",
+						"parsers.0.regex_parser_options.crlf_newline":   "false",
+						"parsers.0.output_name":                         regexp.MustCompile(".+"),
+					}),
+				),
+			},
+			// with explicit target
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_sequentially_processor" "with_target" {
+						title = "custom regex parser title"
+						description = "custom regex parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						target_field = ".data_parsed"
+						parsers = [
+							{
+								parser = "regex_parser"
+								regex_parser_options = {
+									pattern = "\\d{3}-\\d{2}-\\d{3}"
+								}
+							}
+						]
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_parse_sequentially_processor.with_target", "id", regexp.MustCompile(`[\w-]{36}`)),
+
+					StateHasExpectedValues("mezmo_parse_sequentially_processor.with_target", map[string]any{
+						"pipeline_id":                            "#mezmo_pipeline.test_parent.id",
+						"title":                                  "custom regex parser title",
+						"description":                            "custom regex parser desc",
+						"generation_id":                          "0",
+						"inputs.#":                               "0",
+						"field":                                  ".something",
+						"target_field":                           ".data_parsed",
+						"parsers.#":                              "1",
+						"parsers.0.parser":                       "regex_parser",
+						"parsers.0.regex_parser_options.pattern": "\\d{3}-\\d{2}-\\d{3}",
+						"parsers.0.regex_parser_options.case_sensitive": "true",
+						"parsers.0.regex_parser_options.multiline":      "false",
+						"parsers.0.regex_parser_options.match_newline":  "false",
+						"parsers.0.regex_parser_options.crlf_newline":   "false",
+						"parsers.0.output_name":                         regexp.MustCompile(".+"),
+					}),
+				),
+			},
 			// Create regex parser - default options for regex
 			{
 				Config: GetCachedConfig(cacheKey) + `
@@ -478,6 +560,7 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 						"generation_id":                          "0",
 						"inputs.#":                               "0",
 						"field":                                  ".something",
+						"target_field":                           "",
 						"parsers.#":                              "1",
 						"parsers.0.parser":                       "regex_parser",
 						"parsers.0.regex_parser_options.pattern": "\\d{3}-\\d{2}-\\d{3}",
@@ -521,6 +604,7 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 						"generation_id":                          "0",
 						"inputs.#":                               "0",
 						"field":                                  ".something",
+						"target_field":                           "",
 						"parsers.#":                              "1",
 						"parsers.0.parser":                       "regex_parser",
 						"parsers.0.regex_parser_options.pattern": "\\d{3}-\\d{2}-\\d{3}",
@@ -560,6 +644,7 @@ func TestParseSequentiallyProcessor(t *testing.T) {
 						"generation_id":    "0",
 						"inputs.#":         "0",
 						"field":            ".something",
+						"target_field":     "",
 						"parsers.#":        "1",
 						"parsers.0.parser": "csv_row",
 						"parsers.0.csv_row_options.field_names.#": "2",

--- a/internal/provider/models/processors/test/parse_test.go
+++ b/internal/provider/models/processors/test/parse_test.go
@@ -434,6 +434,77 @@ func TestParseProcessor(t *testing.T) {
 					}),
 				),
 			},
+
+			// Parser with empty target_field
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_processor" "with_empty_target" {
+						title = "custom apache parser title"
+						description = "custom apache parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						target_field = ""
+						parser = "apache_log"
+						apache_log_options = {
+							format = "common"
+							timestamp_format = "Custom"
+							custom_timestamp_format = "%Y/%m/%d %H:%M:%S"
+						}
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_parse_processor.with_empty_target", "id", regexp.MustCompile(`[\w-]{36}`)),
+
+					StateHasExpectedValues("mezmo_parse_processor.with_empty_target", map[string]any{
+						"pipeline_id":                         "#mezmo_pipeline.test_parent.id",
+						"title":                               "custom apache parser title",
+						"description":                         "custom apache parser desc",
+						"generation_id":                       "0",
+						"inputs.#":                            "0",
+						"field":                               ".something",
+						"target_field":                        "",
+						"parser":                              "apache_log",
+						"apache_log_options.format":           "common",
+						"apache_log_options.timestamp_format": "Custom",
+						"apache_log_options.custom_timestamp_format": "%Y/%m/%d %H:%M:%S",
+					}),
+				),
+			},
+			// with non empty parser
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_parse_processor" "with_target" {
+						title = "custom apache parser title"
+						description = "custom apache parser desc"
+						pipeline_id = mezmo_pipeline.test_parent.id
+						field = ".something"
+						target_field = ".parsed"
+						parser = "apache_log"
+						apache_log_options = {
+							format = "common"
+							timestamp_format = "Custom"
+							custom_timestamp_format = "%Y/%m/%d %H:%M:%S"
+						}
+					}`,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_parse_processor.with_target", "id", regexp.MustCompile(`[\w-]{36}`)),
+
+					StateHasExpectedValues("mezmo_parse_processor.with_target", map[string]any{
+						"pipeline_id":                         "#mezmo_pipeline.test_parent.id",
+						"title":                               "custom apache parser title",
+						"description":                         "custom apache parser desc",
+						"generation_id":                       "0",
+						"inputs.#":                            "0",
+						"field":                               ".something",
+						"target_field":                        ".parsed",
+						"parser":                              "apache_log",
+						"apache_log_options.format":           "common",
+						"apache_log_options.timestamp_format": "Custom",
+						"apache_log_options.custom_timestamp_format": "%Y/%m/%d %H:%M:%S",
+					}),
+				),
+			},
 			// Create apache parser with default timestamp
 			{
 				Config: GetCachedConfig(cacheKey) + `
@@ -458,6 +529,7 @@ func TestParseProcessor(t *testing.T) {
 						"generation_id":                       "0",
 						"inputs.#":                            "0",
 						"field":                               ".something",
+						"target_field":                        "",
 						"parser":                              "apache_log",
 						"apache_log_options.format":           "common",
 						"apache_log_options.timestamp_format": "%d/%b/%Y:%T %z",
@@ -490,6 +562,7 @@ func TestParseProcessor(t *testing.T) {
 						"generation_id":                       "0",
 						"inputs.#":                            "0",
 						"field":                               ".something",
+						"target_field":                        "",
 						"parser":                              "apache_log",
 						"apache_log_options.format":           "common",
 						"apache_log_options.timestamp_format": "Custom",
@@ -547,6 +620,7 @@ func TestParseProcessor(t *testing.T) {
 						"inputs.#":                           "1",
 						"inputs.0":                           "#mezmo_http_source.my_source.id",
 						"field":                              ".something",
+						"target_field":                       "",
 						"parser":                             "nginx_log",
 						"nginx_log_options.format":           "combined",
 						"nginx_log_options.timestamp_format": "Custom",


### PR DESCRIPTION
The target_field of parse and parse sequential processors are optional. Remove the validation and add tests.
Issue was discovered during QA

Ref: [LOG-18805](https://mezmo.atlassian.net/browse/LOG-18805)

[LOG-18805]: https://mezmo.atlassian.net/browse/LOG-18805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ