### PR TITLE
fix: Do not set string value for no value operators

### DIFF
--- a/internal/provider/models/modelutils/conditional_types.go
+++ b/internal/provider/models/modelutils/conditional_types.go
@@ -191,8 +191,8 @@ func parseExpressionsItem(component map[string]any, level int) (value ObjectValu
 	}
 	if valueNumber, ok := component["value"].(float64); ok {
 		attributeValues["value_number"] = NewFloat64Value(valueNumber)
-	} else {
-		attributeValues["value_string"] = NewStringValue(component["value"].(string))
+	} else if valueString, ok := component["value"].(string); ok && valueString != "" {
+		attributeValues["value_string"] = NewStringValue(valueString)
 	}
 
 	return NewObjectValueMust(ExpressionTypes, attributeValues), false

--- a/internal/provider/models/modelutils/testdata/unwind_conditional.json
+++ b/internal/provider/models/modelutils/testdata/unwind_conditional.json
@@ -206,7 +206,7 @@
                 },
                 {
                   "field": ".field4",
-                  "value_string": "",
+                  "value_string": "null",
                   "operator": "is_array",
                   "value_number": "null"
                 }
@@ -224,13 +224,13 @@
                 },
                 {
                   "field": ".field6",
-                  "value_string": "",
+                  "value_string": "null",
                   "operator": "exists",
                   "value_number": "null"
                 },
                 {
                   "field": ".field7",
-                  "value_string": "",
+                  "value_string": "null",
                   "operator": "not_exists",
                   "value_number": "null"
                 },


### PR DESCRIPTION
No value operators such as is_array, is_metric etc have value set to an empty string. value_string has a min length of 1 and this fails terraform plan.

Ref: LOG-18847