### PR TITLE
fix: Optional strings in the plan

### DIFF
--- a/internal/provider/models/destinations/datadog_logs.go
+++ b/internal/provider/models/destinations/datadog_logs.go
@@ -75,8 +75,12 @@ func DatadogLogsFromModel(plan *DatadogLogsDestinationModel, previousState *Data
 
 func DatadogLogsDestinationToModel(plan *DatadogLogsDestinationModel, component *Destination) {
 	plan.Id = StringValue(component.Id)
-	plan.Title = StringValue(component.Title)
-	plan.Description = StringValue(component.Description)
+	if component.Title != "" {
+		plan.Title = StringValue(component.Title)
+	}
+	if component.Description != "" {
+		plan.Description = StringValue(component.Description)
+	}
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.Inputs = modelutils.SliceToStringListValue(component.Inputs)
 	plan.ApiKey = StringValue(component.UserConfig["api_key"].(string))

--- a/internal/provider/models/destinations/loki.go
+++ b/internal/provider/models/destinations/loki.go
@@ -134,8 +134,12 @@ func LokiFromModel(plan *LokiDestinationModel, previousState *LokiDestinationMod
 
 func LokiDestinationToModel(plan *LokiDestinationModel, component *Destination) {
 	plan.Id = StringValue(component.Id)
-	plan.Title = StringValue(component.Title)
-	plan.Description = StringValue(component.Description)
+	if component.Title != "" {
+		plan.Title = StringValue(component.Title)
+	}
+	if component.Description != "" {
+		plan.Description = StringValue(component.Description)
+	}
 	plan.Inputs = SliceToStringListValue(component.Inputs)
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.AckEnabled = BoolValue(component.UserConfig["ack_enabled"].(bool))

--- a/internal/provider/models/destinations/test/datadog_logs_test.go
+++ b/internal/provider/models/destinations/test/datadog_logs_test.go
@@ -83,7 +83,7 @@ func TestDatadogLogsDestinationResource(t *testing.T) {
 				ExpectError: regexp.MustCompile("Attribute compression value must be one of"),
 			},
 
-			// Test defaults
+			// Test defaults with minimal values
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -93,8 +93,6 @@ func TestDatadogLogsDestinationResource(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 					}`) + `
 					resource "mezmo_datadog_logs_destination" "my_destination" {
-						title       = "my logs destination"
-						description = "logs description"
 						pipeline_id = mezmo_pipeline.test_parent.id
 						site        = "us3"
 						api_key     = "<secret-api-key>"
@@ -107,8 +105,6 @@ func TestDatadogLogsDestinationResource(t *testing.T) {
 
 					StateHasExpectedValues("mezmo_datadog_logs_destination.my_destination", map[string]any{
 						"pipeline_id":   "#mezmo_pipeline.test_parent.id",
-						"title":         "my logs destination",
-						"description":   "logs description",
 						"generation_id": "0",
 						"ack_enabled":   "true",
 						"inputs.#":      "0",

--- a/internal/provider/models/destinations/test/loki_test.go
+++ b/internal/provider/models/destinations/test/loki_test.go
@@ -24,8 +24,6 @@ func TestLokiDestinationResource(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 					}`) + `
 					resource "mezmo_loki_destination" "my_destination" {
-						title = "test destination"
-						description = "loki destination"
 						pipeline_id = mezmo_pipeline.test_parent.id
 						auth = {
 							strategy = "basic"
@@ -44,8 +42,6 @@ func TestLokiDestinationResource(t *testing.T) {
 						"mezmo_loki_destination.my_destination", "id", regexp.MustCompile(`[\w-]{36}`)),
 
 					StateHasExpectedValues("mezmo_loki_destination.my_destination", map[string]any{
-						"title":             "test destination",
-						"description":       "loki destination",
 						"pipeline_id":       "#mezmo_pipeline.test_parent.id",
 						"generation_id":     "0",
 						"ack_enabled":       "true",


### PR DESCRIPTION
Check empty string values before setting it back to the plan.

Ref: LOG-18731