### PR TITLE
chore(reduce):  Add max_events to provider for reduce processor

### DIFF
--- a/docs/resources/reduce_processor.md
+++ b/docs/resources/reduce_processor.md
@@ -27,6 +27,7 @@ Combine multiple events over time into one based on a set of criteria
 - `flush_condition` (Attributes) Force accumulated event reduction to flush the result when a conditional expression evaluates to true on an inbound event. (see [below for nested schema](#nestedatt--flush_condition))
 - `group_by` (List of String) Before reducing, group events based on matching data from each of these field paths. Supports nesting via dot-notation.
 - `inputs` (List of String) The ids of the input components
+- `max_events` (Number) The maximum number of events that can be included in a time window (specified by duration_ms). The reduce operation will stop once it has reached this number of events, regardless of whether the duration_ms have elapsed.
 - `merge_strategies` (Attributes List) Specify merge strategies for individual root-level properties. Dot-notation is supported, but nested field lookup paths will be an error. (see [below for nested schema](#nestedatt--merge_strategies))
 - `title` (String) A user-defined title for the processor
 

--- a/internal/provider/models/processors/test/reduce_test.go
+++ b/internal/provider/models/processors/test/reduce_test.go
@@ -132,6 +132,7 @@ func TestReduceProcessor(t *testing.T) {
 						inputs = [mezmo_http_source.my_source.id]
 
 						duration_ms = 15000
+						max_events = 3
 						group_by    = [".field1.id"]
 						date_formats = [
 							{
@@ -154,6 +155,7 @@ func TestReduceProcessor(t *testing.T) {
 						"generation_id":               "1",
 						"inputs.#":                    "1",
 						"duration_ms":                 "15000",
+						"max_events":                  "3",
 						"group_by.#":                  "1",
 						"group_by.0":                  ".field1.id",
 						"date_formats.#":              "1",


### PR DESCRIPTION
Adds a new config parameter for reduce that allows users to specify the maximum number of events that a reduce operation can contain.

Ref: LOG-19036