### PR TITLE
fix(gcp): Fix setting bucket prefix only if it's not nil

### DIFF
--- a/internal/provider/models/destinations/gcp_cloud_storage.go
+++ b/internal/provider/models/destinations/gcp_cloud_storage.go
@@ -109,7 +109,6 @@ func GcpCloudStorageDestinationFromModel(plan *GcpCloudStorageDestinationModel, 
 				"encoding":           plan.Encoding.ValueString(),
 				"bucket":             plan.Bucket.ValueString(),
 				"compression":        plan.Compression.ValueString(),
-				"bucket_prefix":      plan.BucketPrefix.ValueString(),
 			},
 		},
 	}
@@ -120,6 +119,10 @@ func GcpCloudStorageDestinationFromModel(plan *GcpCloudStorageDestinationModel, 
 		component.UserConfig["api_key"] = GetAttributeValue[String](auth, "value").ValueString()
 	} else {
 		component.UserConfig["credentials_json"] = GetAttributeValue[String](auth, "value").ValueString()
+	}
+
+	if plan.BucketPrefix.ValueString() != "" {
+		component.UserConfig["bucket_prefix"] = plan.BucketPrefix.ValueString()
 	}
 
 	if previousState != nil {
@@ -143,9 +146,12 @@ func GcpCloudStorageDestinationToModel(plan *GcpCloudStorageDestinationModel, co
 	plan.AckEnabled = BoolValue(component.UserConfig["ack_enabled"].(bool))
 	plan.Compression = StringValue(component.UserConfig["compression"].(string))
 	plan.Encoding = StringValue(component.UserConfig["encoding"].(string))
-	plan.BucketPrefix = StringValue(component.UserConfig["bucket_prefix"].(string))
 	plan.Bucket = StringValue(component.UserConfig["bucket"].(string))
 	plan.BatchTimeoutSeconds = Int64Value(int64(component.UserConfig["batch_timeout_secs"].(float64)))
+
+	if component.UserConfig["bucket_prefix"] != nil {
+		plan.BucketPrefix = StringValue(component.UserConfig["bucket_prefix"].(string))
+	}
 
 	authAttrTypes := plan.Auth.AttributeTypes(context.Background())
 	if len(authAttrTypes) == 0 {

--- a/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
@@ -208,7 +208,7 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 				ImportStateIdFunc: ComputeImportId("mezmo_gcp_cloud_storage_destination.my_dest"),
 				ImportStateVerify: true,
 			},
-			// Update fields
+			// Update fields, remove bucket prefix since it's optional
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_http_source" "new_source" {
@@ -222,7 +222,6 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						encoding = "text"
 						compression = "none"
 						bucket = "new_bucket"
-						bucket_prefix = "newprefix"
 						ack_enabled = false
 						auth = {
 							type = "credentials_json"
@@ -242,7 +241,6 @@ func TestGcpCloudStorageSinkResource(t *testing.T) {
 						"encoding":      "text",
 						"compression":   "none",
 						"bucket":        "new_bucket",
-						"bucket_prefix": "newprefix",
 						"auth.type":     "credentials_json",
 						"auth.value":    "{}",
 					}),


### PR DESCRIPTION
Previously, the GCP Cloud Storage destination would convert a nil to an empty string and cause validations against the upstream service. This adds some checks to the type before setting on the tf plan.

Ref: LOG-18742