### PR TITLE
feat: Recreate manually deleted resources

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -110,11 +110,8 @@ func readBody(resp *http.Response, err error) error {
 		return err
 	}
 
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusNoContent {
-		return fmt.Errorf("%s: %s", resp.Status, string(body))
+		return newAPIError(resp)
 	}
 
 	return err
@@ -125,11 +122,8 @@ func readJson(result any, resp *http.Response, err error) error {
 		return err
 	}
 
-	defer resp.Body.Close()
-
 	if resp.StatusCode < http.StatusOK || resp.StatusCode > http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("%s: %s", resp.Status, string(body))
+		return newAPIError(resp)
 	}
 
 	return json.NewDecoder(resp.Body).Decode(result)

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -1,0 +1,40 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type apiResponseError struct {
+	body   string
+	status uint16
+}
+
+func newAPIError(resp *http.Response) apiResponseError {
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+
+	status := uint16(resp.StatusCode)
+	body := ""
+	if err != nil {
+		body = fmt.Sprintf("failed to read response body. reason: %s", err.Error())
+	} else {
+		body = string(respBody)
+	}
+
+	return apiResponseError{
+		body:   body,
+		status: status,
+	}
+}
+
+// implement errors.Error interface
+func (e apiResponseError) Error() string {
+	return fmt.Sprintf("%d: %s", e.status, e.body)
+}
+
+func IsNotFoundError(target error) bool {
+	err, ok := target.(apiResponseError)
+	return ok && err.status == http.StatusNotFound
+}

--- a/internal/provider/models/destinations/test/datadog_logs_test.go
+++ b/internal/provider/models/destinations/test/datadog_logs_test.go
@@ -157,6 +157,35 @@ func TestDatadogLogsDestinationResource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_http_source" "my_source2" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+				}
+				resource "mezmo_datadog_logs_destination" "test_destination" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					site        = "us3"
+					api_key     = "<secret-api-key>"
+					compression = "gzip"
+					inputs = [mezmo_http_source.my_source2.id]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_datadog_logs_destination.test_destination", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_datadog_logs_destination.test_destination", "title", "new title"),
+					// verify resource will be re-created after refresh
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_datadog_logs_destination.test_destination",
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/models/destinations/test/datadog_metrics_test.go
+++ b/internal/provider/models/destinations/test/datadog_metrics_test.go
@@ -134,6 +134,35 @@ func TestDatadogMetricsDestinationResource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_http_source" "my_source2" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+				}
+				resource "mezmo_datadog_metrics_destination" "test_destination" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					site        = "us3"
+					api_key     = "<secret-api-key>"
+					ack_enabled = true
+					inputs = [mezmo_http_source.my_source2.id]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_datadog_metrics_destination.test_destination", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_datadog_metrics_destination.test_destination", "title", "new title"),
+					// verify resource will be re-created after refresh
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_datadog_metrics_destination.test_destination",
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/models/destinations/test/mezmo_test.go
+++ b/internal/provider/models/destinations/test/mezmo_test.go
@@ -177,6 +177,33 @@ func TestMezmoDestinationResource(t *testing.T) {
 					`,
 				ExpectError: regexp.MustCompile("match pattern"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_http_source" "my_source2" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+				}
+				resource "mezmo_logs_destination" "test_destination" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= [mezmo_http_source.my_source2.id]
+					ingestion_key = "my_key"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_logs_destination.test_destination", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_logs_destination.test_destination", "title", "new title"),
+					// verify resource will be re-created after refresh
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_logs_destination.test_destination",
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/destinations/test/s3_test.go
+++ b/internal/provider/models/destinations/test/s3_test.go
@@ -167,6 +167,38 @@ func TestS3DestinationResource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_http_source" "my_source2" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+				}
+				resource "mezmo_s3_destination" "test_destination" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= [mezmo_http_source.my_source2.id]
+					region      = "us-west1"
+					auth = {
+						access_key_id = "my_key"
+						secret_access_key = "my_secret"
+					}
+					bucket = "mybucket"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_s3_destination.test_destination", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_s3_destination.test_destination", "title", "new title"),
+					// verify resource will be re-created after refresh
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_s3_destination.test_destination",
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/destinations/test/splunk_hec_logs_test.go
+++ b/internal/provider/models/destinations/test/splunk_hec_logs_test.go
@@ -229,6 +229,34 @@ func TestSplunkHecLogsDestinationResource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_http_source" "my_source2" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+				}
+				resource "mezmo_splunk_hec_logs_destination" "test_destination" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= [mezmo_http_source.my_source2.id]
+					endpoint    = "https://google.com"
+					token       = "my_token"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_splunk_hec_logs_destination.test_destination", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_splunk_hec_logs_destination.test_destination", "title", "new title"),
+					// verify resource will be re-created after refresh
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_splunk_hec_logs_destination.test_destination",
+					),
+				),
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/aggregate_v2.go
+++ b/internal/provider/models/processors/aggregate_v2.go
@@ -41,7 +41,7 @@ var AggregateV2ProcessorResourceSchema = schema.Schema{
 			Description: "When method is set to tumbling, this is the interval over which metrics are aggregated in millseconds",
 		},
 		"strategy": schema.StringAttribute{
-			Optional:    true,
+			Required:    true,
 			Description: "When method is set to sliding, this is the strategy in which to perform the aggregation",
 		},
 		"window_duration": schema.Int64Attribute{

--- a/internal/provider/models/processors/test/aggregate_v2_test.go
+++ b/internal/provider/models/processors/test/aggregate_v2_test.go
@@ -25,7 +25,7 @@ func TestAggregateV2Processor(t *testing.T) {
 					}`) + `
 					resource "mezmo_aggregate_v2_processor" "my_processor" {
 						method      = "tumbling"
-  						interval    = 36000
+							interval    = 36000
 					}`,
 				ExpectError: regexp.MustCompile("The argument \"pipeline_id\" is required"),
 			},
@@ -38,7 +38,8 @@ func TestAggregateV2Processor(t *testing.T) {
 						description = "Lets aggregate stuff"
 						pipeline_id = mezmo_pipeline.test_parent.id
 						method      = "tumbling"
-  						interval    = 36000
+						interval    = 3600
+						strategy    = "SUM"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
@@ -51,7 +52,8 @@ func TestAggregateV2Processor(t *testing.T) {
 						"generation_id": "0",
 						"inputs.#":      "0",
 						"method":        "tumbling",
-						"interval":      "36000",
+						"interval":      "3600",
+						"strategy":      "SUM",
 					}),
 				),
 			},
@@ -64,7 +66,7 @@ func TestAggregateV2Processor(t *testing.T) {
 						description = "Lets aggregate stuff"
 						pipeline_id = mezmo_pipeline.test_parent.id
 						method      = "tumbling"
-  						interval    = 36000
+							interval    = 36000
 					}`,
 				ImportState:       true,
 				ResourceName:      "mezmo_aggregate_v2_processor.import_target",
@@ -81,7 +83,8 @@ func TestAggregateV2Processor(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						inputs = [mezmo_http_source.my_source.id]
 						method      = "tumbling"
-  						interval    = 3600
+						interval    = 3600
+						strategy    = "SUM"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_aggregate_v2_processor.my_processor", map[string]any{
@@ -93,6 +96,7 @@ func TestAggregateV2Processor(t *testing.T) {
 						"inputs.0":      "#mezmo_http_source.my_source.id",
 						"method":        "tumbling",
 						"interval":      "3600",
+						"strategy":      "SUM",
 					}),
 				),
 			},
@@ -107,7 +111,7 @@ func TestAggregateV2Processor(t *testing.T) {
 						inputs = [mezmo_http_source.my_source.id]
 						method      = "sliding"
 						strategy	= "AVG"
-  						window_duration  = 10
+						window_duration  = 10
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_aggregate_v2_processor.my_processor", map[string]any{
@@ -134,7 +138,7 @@ func TestAggregateV2Processor(t *testing.T) {
 						inputs = [mezmo_http_source.my_source.id]
 						method      = "sliding"
 						strategy	= "AVG"
-  						window_duration  = 10
+							window_duration  = 10
 						conditional = {
 							expressions = [
 								{
@@ -170,10 +174,11 @@ func TestAggregateV2Processor(t *testing.T) {
 				resource "mezmo_aggregate_v2_processor" "my_processor" {
 					pipeline_id = mezmo_pipeline.test_parent.id
 					inputs = [mezmo_http_source.my_source.id]
-					method = "sliding"
-					interval = "3600"
+					method = "tumbling"
+					interval = "36000"
+					strategy    = "SUM"
 				}`,
-				ExpectError: regexp.MustCompile("(?s)have required property.*'strategy'"),
+				ExpectError: regexp.MustCompile("(?s)must.*be <=.*"),
 			},
 
 			// Error: server-side validation for invalid strategy
@@ -185,7 +190,7 @@ func TestAggregateV2Processor(t *testing.T) {
 					method = "sliding"
 					strategy = "asdf"
 				}`,
-				ExpectError: regexp.MustCompile("Bad Request"),
+				ExpectError: regexp.MustCompile("(?s)Bad.*Request"),
 			},
 
 			// Error: server-side validation - invalid window duration
@@ -199,6 +204,33 @@ func TestAggregateV2Processor(t *testing.T) {
 					window_duration = 305325235325
 				}`,
 				ExpectError: regexp.MustCompile("/window_duration/maximum"),
+			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_aggregate_v2_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					method      = "tumbling"
+  				interval    = 3600
+					strategy    = "SUM"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_aggregate_v2_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_aggregate_v2_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_aggregate_v2_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
 			},
 
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/models/processors/test/compact_fields_test.go
+++ b/internal/provider/models/processors/test/compact_fields_test.go
@@ -139,6 +139,31 @@ func TestCompactFieldsProcessor(t *testing.T) {
 				}`,
 				ExpectError: regexp.MustCompile("be a valid data access syntax"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_compact_fields_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					fields 			= [".thing1", ".thing2"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_compact_fields_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_compact_fields_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_compact_fields_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/dedupe_test.go
+++ b/internal/provider/models/processors/test/dedupe_test.go
@@ -139,6 +139,31 @@ func TestDedupeProcessor(t *testing.T) {
 				}`,
 				ExpectError: regexp.MustCompile("be a valid data access syntax"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_dedupe_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					fields 			= [".thing1", ".thing2"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_dedupe_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_dedupe_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_dedupe_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/drop_fields_test.go
+++ b/internal/provider/models/processors/test/drop_fields_test.go
@@ -133,6 +133,31 @@ func TestDropFieldsProcessor(t *testing.T) {
 				}`,
 				ExpectError: regexp.MustCompile("be a valid data access syntax"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_drop_fields_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					fields 			= [".thing1", ".thing2"]
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_drop_fields_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_drop_fields_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_drop_fields_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/encrypt_fields_test.go
+++ b/internal/provider/models/processors/test/encrypt_fields_test.go
@@ -219,6 +219,34 @@ func TestEncryptFieldsProcessor(t *testing.T) {
 				}`,
 				ExpectError: regexp.MustCompile("NOT have fewer than 32"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_encrypt_fields_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					algorithm 	= "AES-128-CFB"
+					key 				= "1111111111111111"
+					iv_field 		= ".some_iv_field"
+					field 			= ".something"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_encrypt_fields_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_encrypt_fields_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_encrypt_fields_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/filter_test.go
+++ b/internal/provider/models/processors/test/filter_test.go
@@ -310,6 +310,40 @@ func TestFilterProcessor(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_filter_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					action 			= "allow"
+					conditional = {
+						expressions = [
+							{
+								field = ".status"
+								operator = "equal"
+								value_number = 200
+							}
+						]
+					}
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_filter_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_filter_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_filter_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/processors/test/reduce_test.go
+++ b/internal/provider/models/processors/test/reduce_test.go
@@ -351,6 +351,30 @@ func TestReduceProcessor(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_reduce_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_reduce_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_reduce_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_reduce_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/sample_test.go
+++ b/internal/provider/models/processors/test/sample_test.go
@@ -230,6 +230,30 @@ func TestSampleProcessor(t *testing.T) {
 				}`,
 				ExpectError: regexp.MustCompile("Value must be a"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_sample_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_sample_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_sample_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_sample_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/script_execution_test.go
+++ b/internal/provider/models/processors/test/script_execution_test.go
@@ -133,6 +133,31 @@ func TestScriptExecutionProcessor(t *testing.T) {
 				}`,
 				ExpectError: regexp.MustCompile("script is not valid JavaScript"),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_script_execution_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+					script 			= "function processEvent(e) { return e }"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_script_execution_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_script_execution_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_script_execution_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/processors/test/stringify_test.go
+++ b/internal/provider/models/processors/test/stringify_test.go
@@ -81,6 +81,30 @@ func TestStringifyProcessorResource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_stringify_processor" "test_processor" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+					inputs 			= []
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_stringify_processor.test_processor", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_stringify_processor.test_processor", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_stringify_processor.test_processor",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/sources/test/agent_test.go
+++ b/internal/provider/models/sources/test/agent_test.go
@@ -137,6 +137,29 @@ func TestAgentSourceResource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_agent_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_agent_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_agent_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_agent_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/sources/test/datadog_test.go
+++ b/internal/provider/models/sources/test/datadog_test.go
@@ -134,6 +134,29 @@ func TestDatadogSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_datadog_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_datadog_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_datadog_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_datadog_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/sources/test/fluent_test.go
+++ b/internal/provider/models/sources/test/fluent_test.go
@@ -151,6 +151,29 @@ func TestFluentSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_fluent_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_fluent_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_fluent_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_fluent_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/sources/test/log_analysis_test.go
+++ b/internal/provider/models/sources/test/log_analysis_test.go
@@ -80,6 +80,29 @@ func TestLogAnalysisSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_log_analysis_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_log_analysis_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_log_analysis_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_log_analysis_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/sources/test/logstash_test.go
+++ b/internal/provider/models/sources/test/logstash_test.go
@@ -149,6 +149,29 @@ func TestLogStashSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_logstash_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_logstash_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_logstash_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_logstash_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/models/sources/test/open_telemetry_traces_test.go
+++ b/internal/provider/models/sources/test/open_telemetry_traces_test.go
@@ -137,6 +137,29 @@ func TestOpenTelemetryTracesSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_open_telemetry_traces_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_open_telemetry_traces_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_open_telemetry_traces_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_open_telemetry_traces_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/sources/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/sources/test/prometheus_remote_write_test.go
@@ -137,6 +137,29 @@ func TestPrometheusRemoteWriteSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_prometheus_remote_write_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_prometheus_remote_write_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_prometheus_remote_write_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_prometheus_remote_write_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/sources/test/splunk_hec_test.go
+++ b/internal/provider/models/sources/test/splunk_hec_test.go
@@ -132,6 +132,29 @@ func TestSplunkHecSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_splunk_hec_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_splunk_hec_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_splunk_hec_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_splunk_hec_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/models/sources/test/webhook_test.go
+++ b/internal/provider/models/sources/test/webhook_test.go
@@ -134,6 +134,29 @@ func TestWebhookSource(t *testing.T) {
 					}),
 				),
 			},
+			// confirm manually deleted resources are recreated
+			{
+				Config: GetProviderConfig() + `
+				resource "mezmo_pipeline" "test_parent2" {
+					title = "pipeline"
+				}
+				resource "mezmo_webhook_source" "test_source" {
+					pipeline_id = mezmo_pipeline.test_parent2.id
+					title 			= "new title"
+				}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"mezmo_webhook_source.test_source", "id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestCheckResourceAttr("mezmo_webhook_source.test_source", "title", "new title"),
+					// delete the resource
+					TestDeletePipelineNodeManually(
+						"mezmo_pipeline.test_parent2",
+						"mezmo_webhook_source.test_source",
+					),
+				),
+				// verify resource will be re-created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
@@ -136,6 +137,11 @@ func (r *PipelineResource) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 
 	pipeline, err := r.client.Pipeline(state.Id.ValueString())
+	// force re-creation of manually deleted resources
+	if client.IsNotFoundError(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Pipeline",

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -44,6 +44,20 @@ func TestPipelineResource(t *testing.T) {
 					resource.TestCheckResourceAttr("mezmo_pipeline.test", "title", "updated title"),
 				),
 			},
+			// manually delete a pipeline and verify it is re-created
+			{
+				Config: GetProviderConfig() + `
+					resource "mezmo_pipeline" "test_deleted" {
+						title = "updated title"
+					}`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mezmo_pipeline.test_deleted", "title", "updated title"),
+					// delete the resource
+					TestDeletePipelineManually("mezmo_pipeline.test_deleted"),
+				),
+				// verify resource is created after refresh
+				ExpectNonEmptyPlan: true,
+			},
 			// Delete testing automatically occurs in TestCase
 		},
 	})

--- a/internal/provider/processor_resource.go
+++ b/internal/provider/processor_resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mezmo/terraform-provider-mezmo/internal/client"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/processors"
@@ -174,6 +175,11 @@ func (r *ProcessorResource[T]) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	component, err := r.client.Processor(r.getPipelineIdFunc(&state).ValueString(), r.getIdFunc(&state).ValueString())
+	// force re-creation of manually deleted resources
+	if client.IsNotFoundError(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error reading processor",

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -4,14 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"os"
 	"reflect"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/mezmo/terraform-provider-mezmo/internal/client"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/sources"
@@ -169,6 +171,11 @@ func (r *SourceResource[T]) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	component, err := r.client.Source(r.getPipelineIdFunc(&state).ValueString(), r.getIdFunc(&state).ValueString())
+	// force re-creation of manually deleted resources
+	if client.IsNotFoundError(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Reading Source",


### PR DESCRIPTION
When plan or apply is run, allow manually deleted resources to be recreated by handling the not found error and updating the state

Ref: LOG-19148