### PR TITLE
fix(ci): Don't swallow errors during example validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
     timestamps()
     ansiColor 'xterm'
     withCredentials(CREDS)
+    disableConcurrentBuilds()
   }
 
   environment {

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BUILD_TAG ?= "1"
+SHELL = '/bin/bash'
 
 default: build
 
@@ -20,7 +21,7 @@ test:
 build-snapshot-binary:
 	$(eval GOOS ?= $(shell go env GOOS))
 	$(eval GOARCH ?= $(shell go env GOARCH))
-	docker run \
+	@docker run \
 	-e GOOS \
 	-e GOARCH \
 	-v $(PWD):/opt/app \
@@ -46,14 +47,15 @@ build-test-example-binary: set-test-example-target build-snapshot-binary
 examples: $(wildcard examples/*/*.tf)
 
 examples/%.tf: build-test-example-binary
-	docker run \
+	@docker run \
 		-v $(PWD):/opt/app \
 		-v $(PWD)/$@:/opt/example/$(notdir $@) \
 		-e TF_CLI_CONFIG_FILE=/opt/app/tf-dev-config \
 		-w /opt/example/ \
 		hashicorp/terraform:latest \
 		validate -compact-warnings | \
-		awk '/Provider development overrides are in effect/ {next} {print}'
+		awk '/Provider development overrides are in effect/ {next} {print}' ; \
+		exit $${PIPESTATUS[0]}
 
 .PHONY: local-test
 ENV := $(PWD)/env/local.env

--- a/examples/processors/parse_sequentially.tf
+++ b/examples/processors/parse_sequentially.tf
@@ -79,7 +79,7 @@ resource "mezmo_blackhole_destination" "destination2" {
 
 resource "mezmo_http_destination" "destination3" {
   pipeline_id = mezmo_pipeline.pipeline1.id
-  title       = "Http desintation"
+  title       = "Http destination"
   description = "Send data to an HTTP destination"
   uri         = "https://example.org"
   inputs      = [mezmo_parse_sequentially_processor.processor1.parsers.2.output_name]
@@ -87,8 +87,7 @@ resource "mezmo_http_destination" "destination3" {
 
 resource "mezmo_blackhole_destination" "destination4" {
   pipeline_id = mezmo_pipeline.pipeline1.id
-  title       = "Http desintation"
+  title       = "Http destination"
   description = "Send unmatched data to a blackhole"
-  uri         = "https://example.org"
   inputs      = [mezmo_parse_sequentially_processor.processor1.unmatched]
 }


### PR DESCRIPTION
This change un-swallows exit codes during example validation. As we were
piping the output to awk, the exit code of the docker command was lost.

Change the shell to bash, and use the PIPESTATUS variable to exit with
the same code as the docker command.
