### PR TITLE
fix(alerts): For `alert_payload`, change `message` to `body`

### DIFF
--- a/docs/resources/absence_alert.md
+++ b/docs/resources/absence_alert.md
@@ -55,12 +55,12 @@ resource "mezmo_absence_alert" "no_data_alert" {
 
 ### Required
 
+- `body` (String) The message body to use when the alert is sent.
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `event_type` (String) The type of event is either a Log event or a Metric event.
 - `ingestion_key` (String) The key required to ingest the alert into Log Analysis
 - `inputs` (List of String) The ids of the input components. This could be the id of a match arm for a route processor, or simply the id of the component.
-- `message` (String) The message body to use when the alert is sent.
 - `name` (String) The name of the alert.
 - `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline

--- a/docs/resources/change_alert.md
+++ b/docs/resources/change_alert.md
@@ -74,13 +74,13 @@ resource "mezmo_change_alert" "order_spike" {
 
 ### Required
 
+- `body` (String) The message body to use when the alert is sent.
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `conditional` (Attributes) A group of expressions (optionally nested) joined by a logical operator (see [below for nested schema](#nestedatt--conditional))
 - `event_type` (String) The type of event is either a Log event or a Metric event.
 - `ingestion_key` (String) The key required to ingest the alert into Log Analysis
 - `inputs` (List of String) The ids of the input components. This could be the id of a match arm for a route processor, or simply the id of the component.
-- `message` (String) The message body to use when the alert is sent.
 - `name` (String) The name of the alert.
 - `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline

--- a/docs/resources/threshold_alert.md
+++ b/docs/resources/threshold_alert.md
@@ -74,13 +74,13 @@ resource "mezmo_threshold_alert" "order_count" {
 
 ### Required
 
+- `body` (String) The message body to use when the alert is sent.
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `conditional` (Attributes) A group of expressions (optionally nested) joined by a logical operator (see [below for nested schema](#nestedatt--conditional))
 - `event_type` (String) The type of event is either a Log event or a Metric event.
 - `ingestion_key` (String) The key required to ingest the alert into Log Analysis
 - `inputs` (List of String) The ids of the input components. This could be the id of a match arm for a route processor, or simply the id of the component.
-- `message` (String) The message body to use when the alert is sent.
 - `name` (String) The name of the alert.
 - `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline

--- a/examples/resources/mezmo_absence_alert/resource.tf
+++ b/examples/resources/mezmo_absence_alert/resource.tf
@@ -30,6 +30,6 @@ resource "mezmo_absence_alert" "no_data_alert" {
   window_duration_minutes = 15
   subject                 = "No data received!"
   severity                = "WARNING"
-  message                 = "There has been no metrics data recieved in the last 15 minutes!"
+  body                    = "There has been no metrics data recieved in the last 15 minutes!"
   ingestion_key           = "abc123"
 }

--- a/examples/resources/mezmo_change_alert/resource.tf
+++ b/examples/resources/mezmo_change_alert/resource.tf
@@ -50,6 +50,6 @@ resource "mezmo_change_alert" "order_spike" {
   window_duration_minutes = 15
   subject                 = "Spike in ordering!"
   severity                = "WARNING"
-  message                 = "There has been a > 20% increase in orders over the last 15 minutes. Check application scaling."
+  body                    = "There has been a > 20% increase in orders over the last 15 minutes. Check application scaling."
   ingestion_key           = "abc123"
 }

--- a/examples/resources/mezmo_threshold_alert/resource.tf
+++ b/examples/resources/mezmo_threshold_alert/resource.tf
@@ -50,6 +50,6 @@ resource "mezmo_threshold_alert" "order_count" {
   window_duration_minutes = 60
   subject                 = "Lots of orders coming in the last hour!"
   severity                = "WARNING"
-  message                 = "Check to make sure there are no errors in pricing, and no unexpected special offers were released."
+  body                    = "Check to make sure there are no errors in pricing, and no unexpected special offers were released."
   ingestion_key           = "abc123"
 }

--- a/internal/provider/models/alerts/absence.go
+++ b/internal/provider/models/alerts/absence.go
@@ -30,7 +30,7 @@ type AbsenceAlertModel struct {
 	Severity          StringValue `tfsdk:"severity" user_config:"true"`
 	Style             StringValue `tfsdk:"style" user_config:"true"`
 	Subject           StringValue `tfsdk:"subject" user_config:"true"`
-	Message           StringValue `tfsdk:"message" user_config:"true"`
+	Body              StringValue `tfsdk:"body" user_config:"true"`
 	IngestionKey      StringValue `tfsdk:"ingestion_key" user_config:"true"`
 }
 
@@ -78,7 +78,7 @@ func AbsenceAlertFromModel(plan *AbsenceAlertModel, previousState *AbsenceAlertM
 			},
 			"alert_payload": map[string]any{
 				"subject": plan.Subject.ValueString(),
-				"message": plan.Message.ValueString(),
+				"body":    plan.Body.ValueString(),
 				"destination": map[string]any{
 					"ingestion_key": plan.IngestionKey.ValueString(),
 				},
@@ -173,6 +173,6 @@ func AbsenceAlertToModel(plan *AbsenceAlertModel, component *Alert) {
 	plan.Severity = NewStringValue(alertPayload["severity"].(string))
 	plan.Style = NewStringValue(alertPayload["style"].(string))
 	plan.Subject = NewStringValue(alertPayload["subject"].(string))
-	plan.Message = NewStringValue(alertPayload["message"].(string))
+	plan.Body = NewStringValue(alertPayload["body"].(string))
 	plan.IngestionKey = NewStringValue(destination["ingestion_key"].(string))
 }

--- a/internal/provider/models/alerts/base_model.go
+++ b/internal/provider/models/alerts/base_model.go
@@ -173,7 +173,7 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 		},
 		Description: "The subject line to use when the alert is sent.", // TODO: Add details about templates when added
 	},
-	"message": schema.StringAttribute{
+	"body": schema.StringAttribute{
 		Required: true,
 		Validators: []validator.String{
 			stringvalidator.LengthAtLeast(1),

--- a/internal/provider/models/alerts/change.go
+++ b/internal/provider/models/alerts/change.go
@@ -31,7 +31,7 @@ type ChangeAlertModel struct {
 	Severity          StringValue `tfsdk:"severity" user_config:"true"`
 	Style             StringValue `tfsdk:"style" user_config:"true"`
 	Subject           StringValue `tfsdk:"subject" user_config:"true"`
-	Message           StringValue `tfsdk:"message" user_config:"true"`
+	Body              StringValue `tfsdk:"body" user_config:"true"`
 	IngestionKey      StringValue `tfsdk:"ingestion_key" user_config:"true"`
 }
 
@@ -86,7 +86,7 @@ func ChangeAlertFromModel(plan *ChangeAlertModel, previousState *ChangeAlertMode
 			},
 			"alert_payload": map[string]any{
 				"subject": plan.Subject.ValueString(),
-				"message": plan.Message.ValueString(),
+				"body":    plan.Body.ValueString(),
 				"destination": map[string]any{
 					"ingestion_key": plan.IngestionKey.ValueString(),
 				},
@@ -182,6 +182,6 @@ func ChangeAlertToModel(plan *ChangeAlertModel, component *Alert) {
 	plan.Severity = NewStringValue(alertPayload["severity"].(string))
 	plan.Style = NewStringValue(alertPayload["style"].(string))
 	plan.Subject = NewStringValue(alertPayload["subject"].(string))
-	plan.Message = NewStringValue(alertPayload["message"].(string))
+	plan.Body = NewStringValue(alertPayload["body"].(string))
 	plan.IngestionKey = NewStringValue(destination["ingestion_key"].(string))
 }

--- a/internal/provider/models/alerts/test/absence_test.go
+++ b/internal/provider/models/alerts/test/absence_test.go
@@ -37,7 +37,7 @@ func TestAbsenceAlert_success(t *testing.T) {
 						event_type = "metric"
 						operation = "sum"
 						subject = "Absence Alert"
-						message = "You received a absence alert"
+						body = "You received a absence alert"
 						ingestion_key = "abc123"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -53,7 +53,7 @@ func TestAbsenceAlert_success(t *testing.T) {
 						"component_kind":          "source",
 						"event_type":              "metric",
 						"ingestion_key":           "abc123",
-						"message":                 "You received a absence alert",
+						"body":                    "You received a absence alert",
 						"name":                    "my absence alert",
 						"operation":               "sum",
 						"severity":                "INFO",
@@ -83,7 +83,7 @@ func TestAbsenceAlert_success(t *testing.T) {
 						group_by = [".other"]
 						severity = "WARNING"
 						subject = "updated subject"
-						message = "updated message"
+						body = "updated body"
 						ingestion_key = "abc123"
 						active = false
 					}`,
@@ -93,7 +93,7 @@ func TestAbsenceAlert_success(t *testing.T) {
 						"description":             "updated description",
 						"group_by.#":              "1",
 						"group_by.0":              ".other",
-						"message":                 "updated message",
+						"body":                    "updated body",
 						"name":                    "updated name",
 						"operation":               "custom",
 						"script":                  "function myFunc(a, e, m) { return a }",
@@ -120,7 +120,7 @@ func TestAbsenceAlert_success(t *testing.T) {
 						event_timestamp = ".timestamp"
 						group_by = [".name", ".namespace", ".tags"]
 						subject = "Absence Alert for Log event"
-						message = "You received a absence alert for a Log event"
+						body = "You received a absence alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -147,7 +147,7 @@ func TestAbsenceAlert_success(t *testing.T) {
 						"severity":                "INFO",
 						"style":                   "static",
 						"subject":                 "Absence Alert for Log event",
-						"message":                 "You received a absence alert for a Log event",
+						"body":                    "You received a absence alert for a Log event",
 						"window_duration_minutes": "5",
 						"window_type":             "tumbling",
 					}),
@@ -191,7 +191,7 @@ func TestAbsenceAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Absence Alert for Log event"
-						message = "This will not work"
+						body = "This will not work"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).*An argument named "conditional" is not expected her`),

--- a/internal/provider/models/alerts/test/change_test.go
+++ b/internal/provider/models/alerts/test/change_test.go
@@ -46,7 +46,7 @@ func TestChangeAlert_success(t *testing.T) {
 							],
 						}
 						subject = "Change Alert"
-						message = "You received a change alert"
+						body = "You received a change alert"
 						ingestion_key = "abc123"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -68,7 +68,7 @@ func TestChangeAlert_success(t *testing.T) {
 						"conditional.logical_operation":          "AND",
 						"event_type":                             "metric",
 						"ingestion_key":                          "abc123",
-						"message":                                "You received a change alert",
+						"body":                                   "You received a change alert",
 						"name":                                   "my change alert",
 						"operation":                              "sum",
 						"severity":                               "INFO",
@@ -107,7 +107,7 @@ func TestChangeAlert_success(t *testing.T) {
 						}
 						severity = "WARNING"
 						subject = "updated subject"
-						message = "updated message"
+						body = "updated body"
 						ingestion_key = "abc123"
 						active = false
 					}`,
@@ -117,7 +117,7 @@ func TestChangeAlert_success(t *testing.T) {
 						"description":                            "updated description",
 						"group_by.#":                             "1",
 						"group_by.0":                             ".other",
-						"message":                                "updated message",
+						"body":                                   "updated body",
 						"name":                                   "updated name",
 						"operation":                              "custom",
 						"conditional.expressions.0.field":        ".other_value",
@@ -156,7 +156,7 @@ func TestChangeAlert_success(t *testing.T) {
 							],
 						}
 						subject = "Change Alert for Log event"
-						message = "You received a change alert for a Log event"
+						body = "You received a change alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -189,7 +189,7 @@ func TestChangeAlert_success(t *testing.T) {
 						"severity":                               "INFO",
 						"style":                                  "static",
 						"subject":                                "Change Alert for Log event",
-						"message":                                "You received a change alert for a Log event",
+						"body":                                   "You received a change alert for a Log event",
 						"window_duration_minutes":                "5",
 						"window_type":                            "tumbling",
 					}),
@@ -233,7 +233,7 @@ func TestChangeAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Change Alert for Log event"
-						message = "You received a change alert for a Log event"
+						body = "You received a change alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*operator value must be one of.*percent_change_less"),

--- a/internal/provider/models/alerts/test/threshold_test.go
+++ b/internal/provider/models/alerts/test/threshold_test.go
@@ -47,7 +47,7 @@ func TestThresholdAlert_success(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert"
-						message = "You received a threshold alert"
+						body = "You received a threshold alert"
 						ingestion_key = "abc123"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -69,7 +69,7 @@ func TestThresholdAlert_success(t *testing.T) {
 						"conditional.logical_operation":          "AND",
 						"event_type":                             "metric",
 						"ingestion_key":                          "abc123",
-						"message":                                "You received a threshold alert",
+						"body":                                   "You received a threshold alert",
 						"name":                                   "my threshold alert",
 						"operation":                              "sum",
 						"severity":                               "INFO",
@@ -107,7 +107,7 @@ func TestThresholdAlert_success(t *testing.T) {
 						}
 						severity = "WARNING"
 						subject = "updated subject"
-						message = "updated message"
+						body = "updated body"
 						ingestion_key = "abc123"
 						active = false
 					}`,
@@ -115,7 +115,7 @@ func TestThresholdAlert_success(t *testing.T) {
 					StateHasExpectedValues("mezmo_threshold_alert.default_metric", map[string]any{
 						"active":                  "false",
 						"description":             "updated description",
-						"message":                 "updated message",
+						"body":                    "updated body",
 						"name":                    "updated name",
 						"operation":               "custom",
 						"script":                  "function myFunc(a, e, m) { return a }",
@@ -151,7 +151,7 @@ func TestThresholdAlert_success(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -184,7 +184,7 @@ func TestThresholdAlert_success(t *testing.T) {
 						"severity":                               "INFO",
 						"style":                                  "static",
 						"subject":                                "Threshold Alert for Log event",
-						"message":                                "You received a threshold alert for a Log event",
+						"body":                                   "You received a threshold alert for a Log event",
 						"window_duration_minutes":                "5",
 						"window_type":                            "tumbling",
 					}),
@@ -216,7 +216,7 @@ func TestThresholdAlert_root_required_errors(t *testing.T) {
 				`The argument "event_type" is required`,
 				`The argument "operation" is required`,
 				`The argument "subject" is required`,
-				`The argument "message" is required`,
+				`The argument "body" is required`,
 				`The argument "ingestion_key" is required`,
 				`The argument "conditional" is required`,
 			}
@@ -278,7 +278,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*operator value must be one of.*"),
@@ -304,7 +304,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*Attribute pipeline_id string length must be at least 1"),
@@ -330,7 +330,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*Attribute component_id string length must be at least 1"),
@@ -356,7 +356,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).*Attribute component_kind value must be one of: \["source" "transform"\]`),
@@ -382,7 +382,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).*Attribute inputs list must contain at least 1 elements`),
@@ -408,7 +408,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).*Attribute inputs\[0\] string length must be at least 1`),
@@ -440,7 +440,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 			// 				],
 			// 			}
 			// 			subject = "Threshold Alert for Log event"
-			// 			message = "You received a threshold alert for a Log event"
+			// 			body = "You received a threshold alert for a Log event"
 			// 			ingestion_key = "abc123"
 			// 		}`,
 			// 	ExpectError: regexp.MustCompile(`(?s).*inputs = \[.*This attribute contains duplicate values of`),
@@ -466,7 +466,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*Attribute name string length must be at least 1"),
@@ -492,7 +492,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).*Attribute event_type value must be one of: \["log" "metric"\]`),
@@ -519,7 +519,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 						}
 						window_type = "badwindow"
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).*Attribute window_type value must be one of: \["tumbling" "sliding"\]`),
@@ -545,7 +545,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 						severity = "invalid"
 					}`,
@@ -572,7 +572,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).Attribute operation value must be one of:`),
@@ -599,7 +599,7 @@ func TestThresholdAlert_schema_validation_errors(t *testing.T) {
 						}
 						style = "NOPE"
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile(`(?s).Attribute style value must be one of:`),
@@ -641,7 +641,7 @@ func TestThresholdAlert_custom_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*A 'custom' operation requires a valid JS `script` function"),
@@ -668,7 +668,7 @@ func TestThresholdAlert_custom_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*`script` cannot be set when `operation` is not 'custom'"),
@@ -694,7 +694,7 @@ func TestThresholdAlert_custom_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*A 'log' event type requires a 'custom' `operation` and a valid JS `script`"),
@@ -721,7 +721,7 @@ func TestThresholdAlert_custom_errors(t *testing.T) {
 							],
 						}
 						subject = "Threshold Alert for Log event"
-						message = "You received a threshold alert for a Log event"
+						body = "You received a threshold alert for a Log event"
 						ingestion_key = "abc123"
 					}`,
 				ExpectError: regexp.MustCompile("(?s).*A 'metric' event type cannot have an `event_timestamp` field"),

--- a/internal/provider/models/alerts/threshold.go
+++ b/internal/provider/models/alerts/threshold.go
@@ -31,7 +31,7 @@ type ThresholdAlertModel struct {
 	Severity          StringValue `tfsdk:"severity" user_config:"true"`
 	Style             StringValue `tfsdk:"style" user_config:"true"`
 	Subject           StringValue `tfsdk:"subject" user_config:"true"`
-	Message           StringValue `tfsdk:"message" user_config:"true"`
+	Body              StringValue `tfsdk:"body" user_config:"true"`
 	IngestionKey      StringValue `tfsdk:"ingestion_key" user_config:"true"`
 }
 
@@ -86,7 +86,7 @@ func ThresholdAlertFromModel(plan *ThresholdAlertModel, previousState *Threshold
 			},
 			"alert_payload": map[string]any{
 				"subject": plan.Subject.ValueString(),
-				"message": plan.Message.ValueString(),
+				"body":    plan.Body.ValueString(),
 				"destination": map[string]any{
 					"ingestion_key": plan.IngestionKey.ValueString(),
 				},
@@ -182,6 +182,6 @@ func ThresholdAlertToModel(plan *ThresholdAlertModel, component *Alert) {
 	plan.Severity = NewStringValue(alertPayload["severity"].(string))
 	plan.Style = NewStringValue(alertPayload["style"].(string))
 	plan.Subject = NewStringValue(alertPayload["subject"].(string))
-	plan.Message = NewStringValue(alertPayload["message"].(string))
+	plan.Body = NewStringValue(alertPayload["body"].(string))
 	plan.IngestionKey = NewStringValue(destination["ingestion_key"].(string))
 }

--- a/pkg/resources/testdata/alerts/absence.json
+++ b/pkg/resources/testdata/alerts/absence.json
@@ -11,7 +11,7 @@
       "destination": {
         "ingestion_key": "abc123"
       },
-      "message": "You received a absence alert for a Log event",
+      "body": "You received a absence alert for a Log event",
       "severity": "INFO",
       "style": "static",
       "subject": "Absence Alert for Log event"

--- a/pkg/resources/testdata/alerts/change.json
+++ b/pkg/resources/testdata/alerts/change.json
@@ -11,7 +11,7 @@
       "destination": {
         "ingestion_key": "abc123"
       },
-      "message": "You received a change alert",
+      "body": "You received a change alert",
       "severity": "INFO",
       "style": "static",
       "subject": "Change Alert"

--- a/pkg/resources/testdata/alerts/threshold.json
+++ b/pkg/resources/testdata/alerts/threshold.json
@@ -11,7 +11,7 @@
       "destination": {
         "ingestion_key": "abc123"
       },
-      "message": "You received a threshold alert for a Log event",
+      "body": "You received a threshold alert for a Log event",
       "severity": "INFO",
       "style": "static",
       "subject": "Threshold Alert for Log event"


### PR DESCRIPTION
This field name was changed to avoid confusion with event `.message` properties.

Ref: LOG-19914