### PR TITLE
refactor(provider)!: Change `gateway_route_id` to `shared_source_id`

### DIFF
--- a/docs/resources/agent_source.md
+++ b/docs/resources/agent_source.md
@@ -40,7 +40,7 @@ resource "mezmo_agent_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared agent source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_agent_source.source1.gateway_route_id
+  shared_source_id = mezmo_agent_source.source1.shared_source_id
 }
 ```
 
@@ -55,7 +55,7 @@ resource "mezmo_agent_source" "shared_source" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/datadog_source.md
+++ b/docs/resources/datadog_source.md
@@ -40,7 +40,7 @@ resource "mezmo_datadog_source" "shared_datadog_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Datadog source"
   description      = "This source uses the same data as datadog1"
-  gateway_route_id = mezmo_datadog_source.datadog1.gateway_route_id
+  shared_source_id = mezmo_datadog_source.datadog1.shared_source_id
 }
 ```
 
@@ -55,7 +55,7 @@ resource "mezmo_datadog_source" "shared_datadog_source" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/fluent_source.md
+++ b/docs/resources/fluent_source.md
@@ -47,7 +47,7 @@ resource "mezmo_fluent_source" "webhook" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared source"
   description      = "This Fluent source uses the webhook data"
-  gateway_route_id = mezmo_http_source.webhook.gateway_route_id
+  shared_source_id = mezmo_http_source.webhook.shared_source_id
 }
 ```
 
@@ -63,7 +63,7 @@ resource "mezmo_fluent_source" "webhook" {
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `decoding` (String) The decoding method for converting frames into data events
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/http_source.md
+++ b/docs/resources/http_source.md
@@ -42,7 +42,7 @@ resource "mezmo_http_source" "shared_source" {
   title            = "A shared HTTP source"
   description      = "This source uses the same data as source1"
   decoding         = "json"
-  gateway_route_id = mezmo_http_source.source1.gateway_route_id
+  shared_source_id = mezmo_http_source.source1.shared_source_id
 }
 ```
 
@@ -58,7 +58,7 @@ resource "mezmo_http_source" "shared_source" {
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `decoding` (String) The decoding method for converting frames into data events.
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/kinesis_firehose_source.md
+++ b/docs/resources/kinesis_firehose_source.md
@@ -24,7 +24,7 @@ Receive Kinesis Firehose data
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `decoding` (String) This specifies what the data format will be after it is base64 decoded. If it is JSON, it will be automatically parsed.
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/logstash_source.md
+++ b/docs/resources/logstash_source.md
@@ -48,7 +48,7 @@ resource "mezmo_logstash_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "Logstash from HTTP"
   description      = "This source uses the same data from the HTTP source (in Logstash format)"
-  gateway_route_id = mezmo_http_source.webhook.gateway_route_id
+  shared_source_id = mezmo_http_source.webhook.shared_source_id
 }
 ```
 
@@ -64,7 +64,7 @@ resource "mezmo_logstash_source" "shared_source" {
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
 - `format` (String) The format of the logstash data
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/open_telemetry_logs_source.md
+++ b/docs/resources/open_telemetry_logs_source.md
@@ -23,7 +23,7 @@ Represents a Open Telemetry Logs source.
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/open_telemetry_metrics_source.md
+++ b/docs/resources/open_telemetry_metrics_source.md
@@ -40,7 +40,7 @@ resource "mezmo_open_telemetry_metrics_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Open Telemetry metrics source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_open_telemetry_metrics_source.source1.gateway_route_id
+  shared_source_id = mezmo_open_telemetry_metrics_source.source1.shared_source_id
 }
 ```
 
@@ -55,7 +55,7 @@ resource "mezmo_open_telemetry_metrics_source" "shared_source" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/open_telemetry_traces_source.md
+++ b/docs/resources/open_telemetry_traces_source.md
@@ -40,7 +40,7 @@ resource "mezmo_open_telemetry_traces_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Open Telemetry Traces source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_open_telemetry_traces_source.source1.gateway_route_id
+  shared_source_id = mezmo_open_telemetry_traces_source.source1.shared_source_id
 }
 ```
 
@@ -55,7 +55,7 @@ resource "mezmo_open_telemetry_traces_source" "shared_source" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/prometheus_remote_write_source.md
+++ b/docs/resources/prometheus_remote_write_source.md
@@ -40,7 +40,7 @@ resource "mezmo_prometheus_remote_write_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Prometheus Remote Write source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_prometheus_remote_write_source.source1.gateway_route_id
+  shared_source_id = mezmo_prometheus_remote_write_source.source1.shared_source_id
 }
 ```
 
@@ -55,7 +55,7 @@ resource "mezmo_prometheus_remote_write_source" "shared_source" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/splunk_hec_source.md
+++ b/docs/resources/splunk_hec_source.md
@@ -48,7 +48,7 @@ resource "mezmo_splunk_hec_source" "splunk_source" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/docs/resources/webhook_source.md
+++ b/docs/resources/webhook_source.md
@@ -48,7 +48,7 @@ resource "mezmo_webhook_source" "my_webhook" {
 
 - `capture_metadata` (Boolean) Enable the inclusion of all http headers and query string parameters that were sent from the source
 - `description` (String) A user-defined value describing the source component
-- `gateway_route_id` (String) The uuid of a pre-existing source to be used as the input for this component. This can only be provided on resource creation (not update).
+- `shared_source_id` (String) The uuid of a pipeline source or shared source to be used as the input for this component. This can only be provided on resource creation (not update).
 - `title` (String) A user-defined title for the source component
 
 ### Read-Only

--- a/examples/resources/mezmo_agent_source/resource.tf
+++ b/examples/resources/mezmo_agent_source/resource.tf
@@ -25,5 +25,5 @@ resource "mezmo_agent_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared agent source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_agent_source.source1.gateway_route_id
+  shared_source_id = mezmo_agent_source.source1.shared_source_id
 }

--- a/examples/resources/mezmo_datadog_source/resource.tf
+++ b/examples/resources/mezmo_datadog_source/resource.tf
@@ -25,5 +25,5 @@ resource "mezmo_datadog_source" "shared_datadog_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Datadog source"
   description      = "This source uses the same data as datadog1"
-  gateway_route_id = mezmo_datadog_source.datadog1.gateway_route_id
+  shared_source_id = mezmo_datadog_source.datadog1.shared_source_id
 }

--- a/examples/resources/mezmo_fluent_source/resource.tf
+++ b/examples/resources/mezmo_fluent_source/resource.tf
@@ -32,5 +32,5 @@ resource "mezmo_fluent_source" "webhook" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared source"
   description      = "This Fluent source uses the webhook data"
-  gateway_route_id = mezmo_http_source.webhook.gateway_route_id
+  shared_source_id = mezmo_http_source.webhook.shared_source_id
 }

--- a/examples/resources/mezmo_http_source/resource.tf
+++ b/examples/resources/mezmo_http_source/resource.tf
@@ -27,5 +27,5 @@ resource "mezmo_http_source" "shared_source" {
   title            = "A shared HTTP source"
   description      = "This source uses the same data as source1"
   decoding         = "json"
-  gateway_route_id = mezmo_http_source.source1.gateway_route_id
+  shared_source_id = mezmo_http_source.source1.shared_source_id
 }

--- a/examples/resources/mezmo_logstash_source/resource.tf
+++ b/examples/resources/mezmo_logstash_source/resource.tf
@@ -33,5 +33,5 @@ resource "mezmo_logstash_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "Logstash from HTTP"
   description      = "This source uses the same data from the HTTP source (in Logstash format)"
-  gateway_route_id = mezmo_http_source.webhook.gateway_route_id
+  shared_source_id = mezmo_http_source.webhook.shared_source_id
 }

--- a/examples/resources/mezmo_open_telemetry_metrics_source/resource.tf
+++ b/examples/resources/mezmo_open_telemetry_metrics_source/resource.tf
@@ -25,5 +25,5 @@ resource "mezmo_open_telemetry_metrics_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Open Telemetry metrics source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_open_telemetry_metrics_source.source1.gateway_route_id
+  shared_source_id = mezmo_open_telemetry_metrics_source.source1.shared_source_id
 }

--- a/examples/resources/mezmo_open_telemetry_traces_source/resource.tf
+++ b/examples/resources/mezmo_open_telemetry_traces_source/resource.tf
@@ -25,5 +25,5 @@ resource "mezmo_open_telemetry_traces_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Open Telemetry Traces source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_open_telemetry_traces_source.source1.gateway_route_id
+  shared_source_id = mezmo_open_telemetry_traces_source.source1.shared_source_id
 }

--- a/examples/resources/mezmo_prometheus_remote_write_source/resource.tf
+++ b/examples/resources/mezmo_prometheus_remote_write_source/resource.tf
@@ -25,5 +25,5 @@ resource "mezmo_prometheus_remote_write_source" "shared_source" {
   pipeline_id      = mezmo_pipeline.pipeline1.id
   title            = "A shared Prometheus Remote Write source"
   description      = "This source uses the same data as source1"
-  gateway_route_id = mezmo_prometheus_remote_write_source.source1.gateway_route_id
+  shared_source_id = mezmo_prometheus_remote_write_source.source1.shared_source_id
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -412,7 +412,7 @@ func (c *client) DeleteAlert(pipelineId string, alert *Alert) error {
 
 // POST Access Key
 func (c *client) CreateAccessKey(accessKey *AccessKey) (*AccessKey, error) {
-	url := fmt.Sprintf("%s/v3/pipeline/gateway-route/%s/access-key", c.endpoint, accessKey.GatewayRouteId)
+	url := fmt.Sprintf("%s/v3/pipeline/gateway-route/%s/access-key", c.endpoint, accessKey.SharedSourceId)
 	reqBody, err := json.Marshal(accessKey)
 	if err != nil {
 		return nil, err
@@ -431,7 +431,7 @@ func (c *client) CreateAccessKey(accessKey *AccessKey) (*AccessKey, error) {
 
 // DELETE access key
 func (c *client) DeleteAccessKey(accessKey *AccessKey) error {
-	url := fmt.Sprintf("%s/v3/pipeline/gateway-route/%s/access-key/%s", c.endpoint, accessKey.GatewayRouteId, accessKey.Id)
+	url := fmt.Sprintf("%s/v3/pipeline/gateway-route/%s/access-key/%s", c.endpoint, accessKey.SharedSourceId, accessKey.Id)
 	req := c.newRequest(http.MethodDelete, url, nil)
 	return readBody(c.httpClient.Do(req))
 }

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -35,7 +35,7 @@ type Alert struct {
 
 type Source struct {
 	BaseNode
-	GatewayRouteId string `json:"gateway_route_id,omitempty"`
+	SharedSourceId string `json:"gateway_route_id,omitempty"`
 }
 
 type Processor struct {
@@ -53,7 +53,7 @@ type Destination struct {
 type AccessKey struct {
 	Id             string `json:"id"`
 	Title          string `json:"title"`
-	GatewayRouteId string `json:"gateway_route_id"`
+	SharedSourceId string `json:"gateway_route_id"`
 	Type           string `json:"type"`
 	Key            string `json:"key,omitempty"`
 }

--- a/internal/provider/models/access_key.go
+++ b/internal/provider/models/access_key.go
@@ -58,7 +58,7 @@ func AccessKeyResourceSchema() schema.Schema {
 func AccessKeyFromModel(plan *AccessKeyResourceModel) *AccessKey {
 	accessKey := AccessKey{
 		Title:          plan.Title.ValueString(),
-		GatewayRouteId: plan.SourceId.ValueString(),
+		SharedSourceId: plan.SourceId.ValueString(),
 		Type:           AccessKeyType,
 	}
 	if !plan.Id.IsUnknown() {
@@ -72,6 +72,6 @@ func AccessKeyFromModel(plan *AccessKeyResourceModel) *AccessKey {
 func AccessKeyToModel(plan *AccessKeyResourceModel, accessKey *AccessKey) {
 	plan.Id = NewStringValue(accessKey.Id)
 	plan.Title = NewStringValue(accessKey.Title)
-	plan.SourceId = NewStringValue(accessKey.GatewayRouteId)
+	plan.SourceId = NewStringValue(accessKey.SharedSourceId)
 	plan.Key = NewStringValue(accessKey.Key)
 }

--- a/internal/provider/models/sources/agent.go
+++ b/internal/provider/models/sources/agent.go
@@ -18,13 +18,13 @@ type AgentSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var AgentSourceResourceSchema = schema.Schema{
 	Description: "Represents a Mezmo agent source.",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func AgentSourceFromModel(plan *AgentSourceModel, previousState *AgentSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func AgentSourceFromModel(plan *AgentSourceModel, previousState *AgentSourceMode
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -77,5 +77,5 @@ func AgentSourceToModel(plan *AgentSourceModel, component *Source) {
 		plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	}
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/base_model.go
+++ b/internal/provider/models/sources/base_model.go
@@ -48,10 +48,10 @@ var addSchemas = map[string]schema.Attribute{
 		Description: "Enable the inclusion of all http headers and query string parameters " +
 			"that were sent from the source",
 	},
-	"gateway_route_id": schema.StringAttribute{
+	"shared_source_id": schema.StringAttribute{
 		Computed: true,
 		Optional: true,
-		Description: "The uuid of a pre-existing source to be used as the input for this " +
+		Description: "The uuid of a pipeline source or shared source to be used as the input for this " +
 			"component. This can only be provided on resource creation (not update).",
 	},
 }

--- a/internal/provider/models/sources/datadog.go
+++ b/internal/provider/models/sources/datadog.go
@@ -18,13 +18,13 @@ type DatadogSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var DatadogSourceResourceSchema = schema.Schema{
 	Description: "Send logs and metrics data directly from an installed datadog agent",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func DatadogSourceFromModel(plan *DatadogSourceModel, previousState *DatadogSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func DatadogSourceFromModel(plan *DatadogSourceModel, previousState *DatadogSour
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -75,5 +75,5 @@ func DatadogSourceToModel(plan *DatadogSourceModel, component *Source) {
 	}
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/fluent.go
+++ b/internal/provider/models/sources/fluent.go
@@ -21,7 +21,7 @@ type FluentSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	Decoding        String `tfsdk:"decoding" user_config:"true"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
@@ -40,7 +40,7 @@ var FluentSourceResourceSchema = schema.Schema{
 				},
 			},
 		},
-		[]string{"capture_metadata", "gateway_route_id"},
+		[]string{"capture_metadata", "shared_source_id"},
 	),
 }
 
@@ -59,20 +59,20 @@ func FluentSourceFromModel(plan *FluentSourceModel, previousState *FluentSourceM
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -92,6 +92,6 @@ func FluentSourceToModel(plan *FluentSourceModel, component *Source) {
 	}
 	plan.Decoding = StringValue(component.UserConfig["decoding"].(string))
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 	plan.GenerationId = Int64Value(component.GenerationId)
 }

--- a/internal/provider/models/sources/http.go
+++ b/internal/provider/models/sources/http.go
@@ -21,7 +21,7 @@ type HttpSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	Decoding        String `tfsdk:"decoding" user_config:"true"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
@@ -39,7 +39,7 @@ var HttpSourceResourceSchema = schema.Schema{
 				stringvalidator.OneOf("bytes", "json", "ndjson", "auto"),
 			},
 		},
-	}, []string{"capture_metadata", "gateway_route_id"}),
+	}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func HttpSourceFromModel(plan *HttpSourceModel, previousState *HttpSourceModel) (*Source, diag.Diagnostics) {
@@ -58,20 +58,20 @@ func HttpSourceFromModel(plan *HttpSourceModel, previousState *HttpSourceModel) 
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -92,5 +92,5 @@ func HttpSourceToModel(plan *HttpSourceModel, component *Source) {
 	plan.Decoding = StringValue(component.UserConfig["decoding"].(string))
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/kinesis_firehose.go
+++ b/internal/provider/models/sources/kinesis_firehose.go
@@ -22,7 +22,7 @@ type KinesisFirehoseSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	Decoding        String `tfsdk:"decoding" user_config:"true"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
@@ -40,7 +40,7 @@ var KinesisFirehoseSourceResourceSchema = schema.Schema{
 				stringvalidator.OneOf("text", "json"),
 			},
 		},
-	}, []string{"capture_metadata", "gateway_route_id"}),
+	}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func KinesisFirehoseSourceFromModel(plan *KinesisFirehoseSourceModel, previousState *KinesisFirehoseSourceModel) (*Source, diag.Diagnostics) {
@@ -58,17 +58,17 @@ func KinesisFirehoseSourceFromModel(plan *KinesisFirehoseSourceModel, previousSt
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+		if !plan.SharedSourceId.IsUnknown() {
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -89,5 +89,5 @@ func KinesisFirehoseSourceToModel(plan *KinesisFirehoseSourceModel, component *S
 	plan.Decoding = StringValue(component.UserConfig["format"].(string))
 	plan.GenerationId = Int64Value(component.GenerationId)
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/logstash.go
+++ b/internal/provider/models/sources/logstash.go
@@ -21,7 +21,7 @@ type LogStashSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	Format          String `tfsdk:"format" user_config:"true"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
@@ -36,7 +36,7 @@ var LogStashSourceResourceSchema = schema.Schema{
 			Description: "The format of the logstash data",
 			Validators:  []validator.String{stringvalidator.OneOf("json", "text")},
 		},
-	}, []string{"capture_metadata", "gateway_route_id"}),
+	}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func LogStashSourceFromModel(plan *LogStashSourceModel, previousState *LogStashSourceModel) (*Source, diag.Diagnostics) {
@@ -55,20 +55,20 @@ func LogStashSourceFromModel(plan *LogStashSourceModel, previousState *LogStashS
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -89,5 +89,5 @@ func LogStashSourceToModel(plan *LogStashSourceModel, component *Source) {
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.Format = StringValue(component.UserConfig["format"].(string))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/open_telemetry_logs.go
+++ b/internal/provider/models/sources/open_telemetry_logs.go
@@ -18,13 +18,13 @@ type OpenTelemetryLogsSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var OpenTelemetryLogsSourceResourceSchema = schema.Schema{
 	Description: "Represents a Open Telemetry Logs source.",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func OpenTelemetryLogsSourceFromModel(plan *OpenTelemetryLogsSourceModel, previousState *OpenTelemetryLogsSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func OpenTelemetryLogsSourceFromModel(plan *OpenTelemetryLogsSourceModel, previo
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -75,5 +75,5 @@ func OpenTelemetryLogsSourceToModel(plan *OpenTelemetryLogsSourceModel, componen
 	}
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/open_telemetry_metrics.go
+++ b/internal/provider/models/sources/open_telemetry_metrics.go
@@ -18,13 +18,13 @@ type OpenTelemetryMetricsSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var OpenTelemetryMetricsSourceResourceSchema = schema.Schema{
 	Description: "Represents a Open Telemetry Metrics source.",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func OpenTelemetryMetricsSourceFromModel(plan *OpenTelemetryMetricsSourceModel, previousState *OpenTelemetryMetricsSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func OpenTelemetryMetricsSourceFromModel(plan *OpenTelemetryMetricsSourceModel, 
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -75,5 +75,5 @@ func OpenTelemetryMetricsSourceToModel(plan *OpenTelemetryMetricsSourceModel, co
 	}
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/open_telemetry_traces.go
+++ b/internal/provider/models/sources/open_telemetry_traces.go
@@ -18,13 +18,13 @@ type OpenTelemetryTracesSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var OpenTelemetryTracesSourceResourceSchema = schema.Schema{
 	Description: "Represents a Open Telemetry Traces source.",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func OpenTelemetryTracesSourceFromModel(plan *OpenTelemetryTracesSourceModel, previousState *OpenTelemetryTracesSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func OpenTelemetryTracesSourceFromModel(plan *OpenTelemetryTracesSourceModel, pr
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -75,5 +75,5 @@ func OpenTelemetryTracesSourceToModel(plan *OpenTelemetryTracesSourceModel, comp
 	}
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/prometheus_remote_write.go
+++ b/internal/provider/models/sources/prometheus_remote_write.go
@@ -18,13 +18,13 @@ type PrometheusRemoteWriteSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var PrometheusRemoteWriteSourceResourceSchema = schema.Schema{
 	Description: "Represents a Prometheus Remote Write source.",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func PrometheusRemoteWriteSourceFromModel(plan *PrometheusRemoteWriteSourceModel, previousState *PrometheusRemoteWriteSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func PrometheusRemoteWriteSourceFromModel(plan *PrometheusRemoteWriteSourceModel
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -77,5 +77,5 @@ func PrometheusRemoteWriteSourceToModel(plan *PrometheusRemoteWriteSourceModel, 
 		plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	}
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }

--- a/internal/provider/models/sources/splunk-hec.go
+++ b/internal/provider/models/sources/splunk-hec.go
@@ -18,7 +18,7 @@ type SplunkHecSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
@@ -26,7 +26,7 @@ var SplunkHecSourceResourceSchema = schema.Schema{
 	Description: "Receive Splunk logs",
 	Attributes: ExtendBaseAttributes(
 		map[string]schema.Attribute{},
-		[]string{"capture_metadata", "gateway_route_id"},
+		[]string{"capture_metadata", "shared_source_id"},
 	),
 }
 
@@ -44,20 +44,20 @@ func SplunkHecSourceFromModel(plan *SplunkHecSourceModel, previousState *SplunkH
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -76,6 +76,6 @@ func SplunkHecSourceToModel(plan *SplunkHecSourceModel, component *Source) {
 		plan.Description = StringValue(component.Description)
 	}
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 	plan.GenerationId = Int64Value(component.GenerationId)
 }

--- a/internal/provider/models/sources/test/agent_test.go
+++ b/internal/provider/models/sources/test/agent_test.go
@@ -38,7 +38,7 @@ func TestAgentSourceResource(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"mezmo_agent_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					resource.TestMatchResourceAttr(
-						"mezmo_agent_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+						"mezmo_agent_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_agent_source.my_source", map[string]any{
 						"description":      "my agent description",
 						"generation_id":    "0",
@@ -80,7 +80,7 @@ func TestAgentSourceResource(t *testing.T) {
 				ImportStateIdFunc: ComputeImportId("mezmo_agent_source.my_source"),
 				ImportStateVerify: true,
 			},
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -94,46 +94,46 @@ func TestAgentSourceResource(t *testing.T) {
 					resource "mezmo_agent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared agent source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_agent_source.my_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_agent_source.my_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_agent_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_agent_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"generation_id":    "0",
 						"title":            "A shared agent source",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_agent_source.my_source.gateway_route_id",
+						"shared_source_id": "#mezmo_agent_source.my_source.shared_source_id",
 					}),
 				),
 			},
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_agent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A new title"
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_agent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title again"
-						gateway_route_id = mezmo_agent_source.my_source.gateway_route_id
+						shared_source_id = mezmo_agent_source.my_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_agent_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_agent_source.shared_source", map[string]any{
 						"title":            "Updated title again",
-						"gateway_route_id": "#mezmo_agent_source.my_source.gateway_route_id",
+						"shared_source_id": "#mezmo_agent_source.my_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/datadog_test.go
+++ b/internal/provider/models/sources/test/datadog_test.go
@@ -34,7 +34,7 @@ func TestDatadogSource(t *testing.T) {
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("mezmo_datadog_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
-					resource.TestMatchResourceAttr("mezmo_datadog_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestMatchResourceAttr("mezmo_datadog_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_datadog_source.my_source", map[string]any{
 						"description":      "my description",
 						"title":            "my title",
@@ -77,7 +77,7 @@ func TestDatadogSource(t *testing.T) {
 				),
 			},
 
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -91,46 +91,46 @@ func TestDatadogSource(t *testing.T) {
 					resource "mezmo_datadog_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_datadog_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_datadog_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_datadog_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_datadog_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"generation_id":    "0",
 						"title":            "A shared source",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_datadog_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_datadog_source.parent_source.shared_source_id",
 					}),
 				),
 			},
 
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_datadog_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
 
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_datadog_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_datadog_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_datadog_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_datadog_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_datadog_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_datadog_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/demo_test.go
+++ b/internal/provider/models/sources/test/demo_test.go
@@ -63,7 +63,7 @@ func TestDemoSourceResource(t *testing.T) {
 						"title":            "my source title",
 						"format":           "json",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": nil,
+						"shared_source_id": nil,
 					}),
 					resource.TestCheckResourceAttrSet("mezmo_demo_source.my_source", "generation_id"),
 				),

--- a/internal/provider/models/sources/test/fluent_test.go
+++ b/internal/provider/models/sources/test/fluent_test.go
@@ -46,7 +46,7 @@ func TestFluentSource(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"mezmo_fluent_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					resource.TestMatchResourceAttr(
-						"mezmo_fluent_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+						"mezmo_fluent_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_fluent_source.my_source", map[string]any{
 						"description":      "my description",
 						"title":            "my title",
@@ -93,7 +93,7 @@ func TestFluentSource(t *testing.T) {
 				),
 			},
 
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -107,47 +107,47 @@ func TestFluentSource(t *testing.T) {
 					resource "mezmo_fluent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_fluent_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_fluent_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_fluent_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_fluent_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"title":            "A shared source",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
 						"generation_id":    "0",
 						"decoding":         "json",
 						"capture_metadata": "false",
-						"gateway_route_id": "#mezmo_fluent_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_fluent_source.parent_source.shared_source_id",
 					}),
 				),
 			},
 
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_fluent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
 
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_fluent_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_fluent_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_fluent_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_fluent_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_fluent_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_fluent_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/http_test.go
+++ b/internal/provider/models/sources/test/http_test.go
@@ -44,7 +44,7 @@ func TestHttpSource(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"mezmo_http_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					resource.TestMatchResourceAttr(
-						"mezmo_http_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+						"mezmo_http_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_http_source.my_source", map[string]any{
 						"description":      "my http description",
 						"generation_id":    "0",
@@ -88,7 +88,7 @@ func TestHttpSource(t *testing.T) {
 					}),
 				),
 			},
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -102,45 +102,45 @@ func TestHttpSource(t *testing.T) {
 					resource "mezmo_http_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared http source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_http_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_http_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_http_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_http_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"generation_id":    "0",
 						"title":            "A shared http source",
 						"decoding":         "auto",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_http_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_http_source.parent_source.shared_source_id",
 					}),
 				),
 			},
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_http_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_http_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_http_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_http_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_http_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_http_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_http_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/kinesis_firehose_test.go
+++ b/internal/provider/models/sources/test/kinesis_firehose_test.go
@@ -93,7 +93,7 @@ func TestKinesisFirehoseSourceResource(t *testing.T) {
 					}),
 				),
 			},
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: providertest.SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -108,7 +108,7 @@ func TestKinesisFirehoseSourceResource(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "shared"
 						description = "shared kinesis source"
-						gateway_route_id = mezmo_kinesis_firehose_source.parent_source.id
+						shared_source_id = mezmo_kinesis_firehose_source.parent_source.id
 					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
@@ -121,32 +121,32 @@ func TestKinesisFirehoseSourceResource(t *testing.T) {
 						"decoding":         "json",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_kinesis_firehose_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_kinesis_firehose_source.parent_source.shared_source_id",
 					}),
 				),
 			},
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: providertest.GetCachedConfig(cacheKey) + `
 					resource "mezmo_kinesis_firehose_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id =  mezmo_pipeline.test_parent.id
+						shared_source_id =  mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: providertest.GetCachedConfig(cacheKey) + `
 					resource "mezmo_kinesis_firehose_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "another title update"
-						gateway_route_id = mezmo_kinesis_firehose_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_kinesis_firehose_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					providertest.StateHasExpectedValues("mezmo_kinesis_firehose_source.shared_source", map[string]any{
 						"title":            "another title update",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_kinesis_firehose_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_kinesis_firehose_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/log_analysis_test.go
+++ b/internal/provider/models/sources/test/log_analysis_test.go
@@ -37,7 +37,7 @@ func TestLogAnalysisSource(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"mezmo_log_analysis_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 
-					resource.TestCheckNoResourceAttr("mezmo_log_analysis_source.my_source", "gateway_route_id"),
+					resource.TestCheckNoResourceAttr("mezmo_log_analysis_source.my_source", "shared_source_id"),
 
 					StateHasExpectedValues("mezmo_log_analysis_source.my_source", map[string]any{
 						"description":   "my source description",

--- a/internal/provider/models/sources/test/logstash_test.go
+++ b/internal/provider/models/sources/test/logstash_test.go
@@ -44,7 +44,7 @@ func TestLogStashSource(t *testing.T) {
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("mezmo_logstash_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
-					resource.TestMatchResourceAttr("mezmo_logstash_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestMatchResourceAttr("mezmo_logstash_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_logstash_source.my_source", map[string]any{
 						"description":      "my description",
 						"title":            "my title",
@@ -91,7 +91,7 @@ func TestLogStashSource(t *testing.T) {
 				),
 			},
 
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -105,47 +105,47 @@ func TestLogStashSource(t *testing.T) {
 					resource "mezmo_logstash_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_logstash_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_logstash_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_logstash_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_logstash_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"generation_id":    "0",
 						"title":            "A shared source",
 						"format":           "json",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_logstash_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_logstash_source.parent_source.shared_source_id",
 					}),
 				),
 			},
 
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_logstash_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
 
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_logstash_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_logstash_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_logstash_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_logstash_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_logstash_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_logstash_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/open_telemetry_test.go
+++ b/internal/provider/models/sources/test/open_telemetry_test.go
@@ -20,7 +20,7 @@ type resourceOpenTelemetrySourceConfig struct {
 	SourceDesc      string
 	CaptureMetadata bool
 
-	// Will include a shared source which means setting the gateway_route_id on
+	// Will include a shared source which means setting the shared_source_id on
 	// source A to the ID of source B.
 	GatewayResourceID string
 }
@@ -43,7 +43,7 @@ resource "mezmo_open_telemetry_{{.Type}}_source" "{{.SourceName}}" {
 {{if .GatewayResourceID}}
 resource "mezmo_open_telemetry_{{.Type}}_source" "{{.SourceName}}-gateway" {
 	pipeline_id      = mezmo_pipeline.{{.PipelineName}}.id
-	gateway_route_id = {{.GatewayResourceID}}
+	shared_source_id = {{.GatewayResourceID}}
 }
 {{end}}
 `
@@ -93,7 +93,7 @@ func TestAccOpenTelemetrySources(t *testing.T) {
 			SourceName:        sourceName,
 			SourceTitle:       sourceTitle,
 			SourceDesc:        sourceDesc,
-			GatewayResourceID: resourceName + ".gateway_route_id",
+			GatewayResourceID: resourceName + ".shared_source_id",
 		}, resourceOpenTelemetrySourceConfigTpl)
 		if err != nil {
 			t.Fatalf("error parsing config template: %s", err)
@@ -133,7 +133,7 @@ func TestAccOpenTelemetrySources(t *testing.T) {
 					Config: GetProviderConfig() + config,
 					Check: resource.ComposeTestCheckFunc([]resource.TestCheckFunc{
 						resource.TestMatchResourceAttr(resourceName, "id", IDRegex),
-						resource.TestMatchResourceAttr(resourceName, "gateway_route_id", IDRegex),
+						resource.TestMatchResourceAttr(resourceName, "shared_source_id", IDRegex),
 						resource.TestCheckResourceAttr(resourceName, "description", "my open telemetry description"),
 						resource.TestCheckResourceAttr(resourceName, "generation_id", "0"),
 						resource.TestCheckResourceAttr(resourceName, "title", "my open telemetry title"),
@@ -158,19 +158,19 @@ func TestAccOpenTelemetrySources(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "capture_metadata", "true"),
 					}...),
 				},
-				// Supply gateway_route_id
+				// Supply shared_source_id
 				{
 					Config: GetProviderConfig() + configGateway,
 					Check: resource.ComposeTestCheckFunc([]resource.TestCheckFunc{
 						resource.TestCheckResourceAttrPair(
 							resourceNameGateway,
-							"gateway_route_id",
+							"shared_source_id",
 							resourceName,
-							"gateway_route_id",
+							"shared_source_id",
 						),
 					}...),
 				},
-				// Updating gateway_route_id is not allowed
+				// Updating shared_source_id is not allowed
 				{
 					Config:      GetProviderConfig() + configGatewayUpdateErr,
 					ExpectError: regexp.MustCompile("This field is immutable after resource creation."),

--- a/internal/provider/models/sources/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/sources/test/prometheus_remote_write_test.go
@@ -41,7 +41,7 @@ func TestPrometheusRemoteWriteSource(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"mezmo_prometheus_remote_write_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					resource.TestMatchResourceAttr(
-						"mezmo_prometheus_remote_write_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+						"mezmo_prometheus_remote_write_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_prometheus_remote_write_source.my_source", map[string]any{
 						"description":      "my prometheus remote write description",
 						"generation_id":    "0",
@@ -82,7 +82,7 @@ func TestPrometheusRemoteWriteSource(t *testing.T) {
 					}),
 				),
 			},
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -96,44 +96,44 @@ func TestPrometheusRemoteWriteSource(t *testing.T) {
 					resource "mezmo_prometheus_remote_write_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared prometheus remote write source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_prometheus_remote_write_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_prometheus_remote_write_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_prometheus_remote_write_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_prometheus_remote_write_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"generation_id":    "0",
 						"title":            "A shared prometheus remote write source",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_prometheus_remote_write_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_prometheus_remote_write_source.parent_source.shared_source_id",
 					}),
 				),
 			},
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_prometheus_remote_write_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_prometheus_remote_write_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_prometheus_remote_write_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_prometheus_remote_write_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_prometheus_remote_write_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_prometheus_remote_write_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_prometheus_remote_write_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/splunk_hec_test.go
+++ b/internal/provider/models/sources/test/splunk_hec_test.go
@@ -36,7 +36,7 @@ func TestSplunkHecSource(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"mezmo_splunk_hec_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					resource.TestMatchResourceAttr(
-						"mezmo_splunk_hec_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+						"mezmo_splunk_hec_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 
 					StateHasExpectedValues("mezmo_splunk_hec_source.my_source", map[string]any{
 						"description":      "my description",
@@ -78,7 +78,7 @@ func TestSplunkHecSource(t *testing.T) {
 					}),
 				),
 			},
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -92,43 +92,43 @@ func TestSplunkHecSource(t *testing.T) {
 					resource "mezmo_splunk_hec_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared splunk HEC source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_splunk_hec_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_splunk_hec_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_splunk_hec_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_splunk_hec_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"title":            "A shared splunk HEC source",
 						"generation_id":    "0",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_splunk_hec_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_splunk_hec_source.parent_source.shared_source_id",
 					}),
 				),
 			},
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_splunk_hec_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_splunk_hec_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_splunk_hec_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_splunk_hec_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_splunk_hec_source.shared_source", map[string]any{
 						"title":            "Updated title",
-						"gateway_route_id": "#mezmo_splunk_hec_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_splunk_hec_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/test/webhook_test.go
+++ b/internal/provider/models/sources/test/webhook_test.go
@@ -34,7 +34,7 @@ func TestWebhookSource(t *testing.T) {
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("mezmo_webhook_source.my_source", "id", regexp.MustCompile(`[\w-]{36}`)),
-					resource.TestMatchResourceAttr("mezmo_webhook_source.my_source", "gateway_route_id", regexp.MustCompile(`[\w-]{36}`)),
+					resource.TestMatchResourceAttr("mezmo_webhook_source.my_source", "shared_source_id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_webhook_source.my_source", map[string]any{
 						"description":      "my description",
 						"title":            "my title",
@@ -77,7 +77,7 @@ func TestWebhookSource(t *testing.T) {
 				),
 			},
 
-			// Supply gateway_route_id
+			// Supply shared_source_id
 			{
 				Config: SetCachedConfig(cacheKey, `
 					resource "mezmo_pipeline" "test_parent" {
@@ -91,46 +91,46 @@ func TestWebhookSource(t *testing.T) {
 					resource "mezmo_webhook_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "A shared source"
-						description = "This source provides gateway_route_id"
-						gateway_route_id = mezmo_webhook_source.parent_source.gateway_route_id
+						description = "This source provides shared_source_id"
+						shared_source_id = mezmo_webhook_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
 						"mezmo_webhook_source.shared_source", "id", regexp.MustCompile(`[\w-]{36}`)),
 					StateHasExpectedValues("mezmo_webhook_source.shared_source", map[string]any{
-						"description":      "This source provides gateway_route_id",
+						"description":      "This source provides shared_source_id",
 						"generation_id":    "0",
 						"title":            "A shared source",
 						"capture_metadata": "false",
 						"pipeline_id":      "#mezmo_pipeline.test_parent.id",
-						"gateway_route_id": "#mezmo_webhook_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_webhook_source.parent_source.shared_source_id",
 					}),
 				),
 			},
 
-			// Updating gateway_route_id is not allowed
+			// Updating shared_source_id is not allowed
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_webhook_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
-						gateway_route_id = mezmo_pipeline.test_parent.id
+						shared_source_id = mezmo_pipeline.test_parent.id
 					}`,
 				ExpectError: regexp.MustCompile("This field is immutable after resource creation."),
 			},
 
-			// gateway_route_id can be specified if it's the same value
+			// shared_source_id can be specified if it's the same value
 			{
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_webhook_source" "shared_source" {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "Updated title"
-						gateway_route_id = mezmo_webhook_source.parent_source.gateway_route_id
+						shared_source_id = mezmo_webhook_source.parent_source.shared_source_id
 					}`,
 				Check: resource.ComposeTestCheckFunc(
 					StateHasExpectedValues("mezmo_webhook_source.shared_source", map[string]any{
 						"title":            "Updated title",
 						"generation_id":    "1",
-						"gateway_route_id": "#mezmo_webhook_source.parent_source.gateway_route_id",
+						"shared_source_id": "#mezmo_webhook_source.parent_source.shared_source_id",
 					}),
 				),
 			},

--- a/internal/provider/models/sources/webhook.go
+++ b/internal/provider/models/sources/webhook.go
@@ -18,13 +18,13 @@ type WebhookSourceModel struct {
 	Title           String `tfsdk:"title"`
 	Description     String `tfsdk:"description"`
 	GenerationId    Int64  `tfsdk:"generation_id"`
-	GatewayRouteId  String `tfsdk:"gateway_route_id"`
+	SharedSourceId  String `tfsdk:"shared_source_id"`
 	CaptureMetadata Bool   `tfsdk:"capture_metadata" user_config:"true"`
 }
 
 var WebhookSourceResourceSchema = schema.Schema{
 	Description: "Receive data from incoming webhooks using the WebSub protocol",
-	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "gateway_route_id"}),
+	Attributes:  ExtendBaseAttributes(map[string]schema.Attribute{}, []string{"capture_metadata", "shared_source_id"}),
 }
 
 func WebhookSourceFromModel(plan *WebhookSourceModel, previousState *WebhookSourceModel) (*Source, diag.Diagnostics) {
@@ -42,20 +42,20 @@ func WebhookSourceFromModel(plan *WebhookSourceModel, previousState *WebhookSour
 	}
 
 	if previousState == nil {
-		if !plan.GatewayRouteId.IsUnknown() {
+		if !plan.SharedSourceId.IsUnknown() {
 			// Let them specify gateway route id on POST only
-			component.GatewayRouteId = plan.GatewayRouteId.ValueString()
+			component.SharedSourceId = plan.SharedSourceId.ValueString()
 		}
 	} else {
 		// Set generated fields
 		component.Id = previousState.Id.ValueString()
 		component.GenerationId = previousState.GenerationId.ValueInt64()
 
-		// If they have specified gateway_route_id, then it *cannot* be a different value that what's in state
-		if !plan.GatewayRouteId.IsUnknown() && plan.GatewayRouteId.ValueString() != previousState.GatewayRouteId.ValueString() {
+		// If they have specified shared_source_id, then it *cannot* be a different value that what's in state
+		if !plan.SharedSourceId.IsUnknown() && plan.SharedSourceId.ValueString() != previousState.SharedSourceId.ValueString() {
 			details := fmt.Sprintf(
-				"Cannot update \"gateway_route_id\" to %s. This field is immutable after resource creation.",
-				plan.GatewayRouteId,
+				"Cannot update \"shared_source_id\" to %s. This field is immutable after resource creation.",
+				plan.SharedSourceId,
 			)
 			dd.AddError("Error in plan", details)
 			return nil, dd
@@ -75,5 +75,5 @@ func WebhookSourceToModel(plan *WebhookSourceModel, component *Source) {
 	}
 	plan.CaptureMetadata = BoolValue(component.UserConfig["capture_metadata"].(bool))
 	plan.GenerationId = Int64Value(component.GenerationId)
-	plan.GatewayRouteId = StringValue(component.GatewayRouteId)
+	plan.SharedSourceId = StringValue(component.SharedSourceId)
 }


### PR DESCRIPTION
This provider should not expose internal terminology such as what "gateway routes" are used for. To a user, these are shared sources, and they should be renamed as such. This also fits in with the recent addition of creating shared sources independently, since they are already called "shared sources."

BREAKING CHANGE: The renaming of this field in the schema will break users of this provider, and thus this should be a `major` release.

Ref: LOG-19968