### PR TITLE
chore(alerts): Add `template` as a style

### DIFF
--- a/docs/resources/absence_alert.md
+++ b/docs/resources/absence_alert.md
@@ -55,7 +55,10 @@ resource "mezmo_absence_alert" "no_data_alert" {
 
 ### Required
 
-- `body` (String) The message body to use when the alert is sent.
+- `body` (String) The message body to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
+```
+{{.my_field}} had a count of {{metadata.aggregate.event_count}}
+```
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `event_type` (String) The type of event is either a Log event or a Metric event.
@@ -64,7 +67,10 @@ resource "mezmo_absence_alert" "no_data_alert" {
 - `name` (String) The name of the alert.
 - `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline
-- `subject` (String) The subject line to use when the alert is sent.
+- `subject` (String) The subject line to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
+```
+{{.my_field}} had a count of {{metadata.aggregate.event_count}}
+```
 
 ### Optional
 
@@ -74,7 +80,7 @@ resource "mezmo_absence_alert" "no_data_alert" {
 - `group_by` (List of String) When aggregating, group events based on matching values from each of these field paths. Supports nesting via dot-notation. This value is optional for Metric event types, and SHOULD be used for Log event types.
 - `script` (String) A custom JavaScript function that will control the aggregation. At the time of flushing, this aggregation will become the emitted event. This script is required when choosing a `custom` operation.
 - `severity` (String) The severity level of the alert.
-- `style` (String) Configuration for how the alert message will be constructed.
+- `style` (String) Configuration for how the alert message will be constructed. For `static`, exact strings will be used. For `template`, the alert subjec and body will allow for placeholders to substitute values from the event.
 - `window_duration_minutes` (Number) The duration of the aggregation window in minutes.
 - `window_type` (String) Sliding windows can overlap, whereas tumbling windows are disjoint. For example, a tumbling window has a fixed time span and any events that fall within the "window duration" will be used in the aggregate. In a sliding window, the aggregation occurs every "window duration" seconds after an event is encountered.
 

--- a/docs/resources/change_alert.md
+++ b/docs/resources/change_alert.md
@@ -74,7 +74,10 @@ resource "mezmo_change_alert" "order_spike" {
 
 ### Required
 
-- `body` (String) The message body to use when the alert is sent.
+- `body` (String) The message body to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
+```
+{{.my_field}} had a count of {{metadata.aggregate.event_count}}
+```
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `conditional` (Attributes) A group of expressions (optionally nested) joined by a logical operator (see [below for nested schema](#nestedatt--conditional))
@@ -84,7 +87,10 @@ resource "mezmo_change_alert" "order_spike" {
 - `name` (String) The name of the alert.
 - `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline
-- `subject` (String) The subject line to use when the alert is sent.
+- `subject` (String) The subject line to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
+```
+{{.my_field}} had a count of {{metadata.aggregate.event_count}}
+```
 
 ### Optional
 
@@ -94,7 +100,7 @@ resource "mezmo_change_alert" "order_spike" {
 - `group_by` (List of String) When aggregating, group events based on matching values from each of these field paths. Supports nesting via dot-notation. This value is optional for Metric event types, and SHOULD be used for Log event types.
 - `script` (String) A custom JavaScript function that will control the aggregation. At the time of flushing, this aggregation will become the emitted event. This script is required when choosing a `custom` operation.
 - `severity` (String) The severity level of the alert.
-- `style` (String) Configuration for how the alert message will be constructed.
+- `style` (String) Configuration for how the alert message will be constructed. For `static`, exact strings will be used. For `template`, the alert subjec and body will allow for placeholders to substitute values from the event.
 - `window_duration_minutes` (Number) The duration of the aggregation window in minutes.
 - `window_type` (String) Sliding windows can overlap, whereas tumbling windows are disjoint. For example, a tumbling window has a fixed time span and any events that fall within the "window duration" will be used in the aggregate. In a sliding window, the aggregation occurs every "window duration" seconds after an event is encountered.
 

--- a/docs/resources/threshold_alert.md
+++ b/docs/resources/threshold_alert.md
@@ -74,7 +74,10 @@ resource "mezmo_threshold_alert" "order_count" {
 
 ### Required
 
-- `body` (String) The message body to use when the alert is sent.
+- `body` (String) The message body to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
+```
+{{.my_field}} had a count of {{metadata.aggregate.event_count}}
+```
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `conditional` (Attributes) A group of expressions (optionally nested) joined by a logical operator (see [below for nested schema](#nestedatt--conditional))
@@ -84,7 +87,10 @@ resource "mezmo_threshold_alert" "order_count" {
 - `name` (String) The name of the alert.
 - `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline
-- `subject` (String) The subject line to use when the alert is sent.
+- `subject` (String) The subject line to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
+```
+{{.my_field}} had a count of {{metadata.aggregate.event_count}}
+```
 
 ### Optional
 
@@ -94,7 +100,7 @@ resource "mezmo_threshold_alert" "order_count" {
 - `group_by` (List of String) When aggregating, group events based on matching values from each of these field paths. Supports nesting via dot-notation. This value is optional for Metric event types, and SHOULD be used for Log event types.
 - `script` (String) A custom JavaScript function that will control the aggregation. At the time of flushing, this aggregation will become the emitted event. This script is required when choosing a `custom` operation.
 - `severity` (String) The severity level of the alert.
-- `style` (String) Configuration for how the alert message will be constructed.
+- `style` (String) Configuration for how the alert message will be constructed. For `static`, exact strings will be used. For `template`, the alert subjec and body will allow for placeholders to substitute values from the event.
 - `window_duration_minutes` (Number) The duration of the aggregation window in minutes.
 - `window_type` (String) Sliding windows can overlap, whereas tumbling windows are disjoint. For example, a tumbling window has a fixed time span and any events that fall within the "window duration" will be used in the aggregate. In a sliding window, the aggregation occurs every "window duration" seconds after an event is encountered.
 

--- a/internal/provider/models/alerts/base_model.go
+++ b/internal/provider/models/alerts/base_model.go
@@ -157,11 +157,13 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 		Default: stringdefault.StaticString("INFO"),
 	},
 	"style": schema.StringAttribute{
-		Optional:    true,
-		Computed:    true,
-		Description: "Configuration for how the alert message will be constructed.",
+		Optional: true,
+		Computed: true,
+		Description: "Configuration for how the alert message will be constructed. For " +
+			"`static`, exact strings will be used. For `template`, the alert subjec and body " +
+			"will allow for placeholders to substitute values from the event.",
 		Validators: []validator.String{
-			stringvalidator.OneOf("static"),
+			stringvalidator.OneOf("static", "template"),
 		},
 		Default: stringdefault.StaticString("static"),
 	},
@@ -171,7 +173,9 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 			stringvalidator.LengthAtLeast(1),
 			stringvalidator.LengthAtMost(200),
 		},
-		Description: "The subject line to use when the alert is sent.", // TODO: Add details about templates when added
+		MarkdownDescription: "The subject line to use when the alert is sent. For a `template` style, " +
+			"surround the field path in double curly braces.\n" +
+			"```\n" + `{{"{{.my_field}} had a count of {{metadata.aggregate.event_count}}"}}` + "\n```",
 	},
 	"body": schema.StringAttribute{
 		Required: true,
@@ -179,7 +183,9 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 			stringvalidator.LengthAtLeast(1),
 			stringvalidator.LengthAtMost(1024),
 		},
-		Description: "The message body to use when the alert is sent.", // TODO: Add details about templates when added
+		Description: "The message body to use when the alert is sent. For a `template` style, " +
+			"surround the field path in double curly braces.\n" +
+			"```\n" + `{{"{{.my_field}} had a count of {{metadata.aggregate.event_count}}"}}` + "\n```",
 	},
 	"ingestion_key": schema.StringAttribute{
 		Required: true,


### PR DESCRIPTION
Alert `body` and `subject` can now use template styling.

Ref: LOG-20001