### PR TITLE
fix(destinations): Prometheus destination doesn't repsect `ack_enabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,44 +11,45 @@ You can download this repo to create your own local provider or you can use the 
 - [Go](https://golang.org/doc/install) >= 1.20
 
 ## Building the Provider Locally
-
+Building the provider will build the provider binary in the project root. It's not very useful in most
+cases, so see the instructions in [Running the Provider Locally](#running-the-provider-locally).
 ```shell
 go build ./...
 ```
 
-## Generating the Docs
+## Running the Provider Locally
 
-To generate or update documentation, run `go generate`.
+To build and install the provider locally, run `go install .`. This will build the provider and put the provider
+binary in the `$GOPATH/bin` directory. You will reference this location in the next step.
 
-## Using the Provider
+### Adding the Provider Override
 
-To install the provider in development, run `go install .`. This will build the provider and put the provider
-binary in the `$GOPATH/bin` directory.
-
-## Adding the Provider override
-
-If you want to use the local provider, you need to reference it by placing a file in your home folder under `~/.terraformrc` as follows:
+If you want to use the local provider, you need to reference it by placing a file in your `$HOME` directory called `.terraformrc`.
+This setting tells terraform to override the remote registry where the provider is usually downloaded from in favor of a local directory.
+The value of this setting should be your `$GOPATH`, which is where the installed binary gets placed.
+This value is usually `$HOME/go/bin`.
 ```
 provider_installation {
-
   dev_overrides {
       "registry.terraform.io/mezmo/mezmo" = "/Users/<YOUR USERNAME>/go/bin"
   }
-
-  # For all other providers, install them directly from their origin provider
-  # registries as normal. If you omit this, Terraform will _only_ use
-  # the dev_overrides block, and so no other providers will be available.
-  direct {}
 }
 ```
 
-Then, you can `plan` or `apply` a terraform files:
+Then, you can `plan` or `apply` a terraform files. This example assumes that there are `.tf`
+files in `my-terraform-test` ready to be used.
 
 ```bash
-pushd examples/pipeline
+cd my-terraform-test
+terraform init
 terraform plan
-popd
+terraform apply
 ```
+
+## Generating the Docs
+
+When schemas are changed (descriptions, types) during development, the documentation for the components must be re-generated.
+To do this, run `go generate` to make sure all changes are documented.
 
 ## Testing
 

--- a/internal/provider/models/destinations/prometheus_remote_write.go
+++ b/internal/provider/models/destinations/prometheus_remote_write.go
@@ -92,6 +92,10 @@ func PrometheusRemoteWriteDestinationFromModel(plan *PrometheusRemoteWriteDestin
 		},
 	}
 
+	if !plan.AckEnabled.IsUnknown() {
+		component.UserConfig["ack_enabled"] = plan.AckEnabled.ValueBool()
+	}
+
 	if !plan.Auth.IsNull() {
 		auth := MapValuesToMapAny(plan.Auth, &dd)
 		component.UserConfig["auth"] = auth

--- a/internal/provider/models/destinations/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/destinations/test/prometheus_remote_write_test.go
@@ -140,6 +140,7 @@ func TestPrometheusDestinationResource(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						inputs = [mezmo_http_source.my_source.id]
 						endpoint = "https://google.com"
+						ack_enabled = false
 						auth = {
 							strategy = "basic"
 							user = "my_user"
@@ -156,7 +157,7 @@ func TestPrometheusDestinationResource(t *testing.T) {
 						"title":         "My destination",
 						"description":   "my destination description",
 						"generation_id": "1",
-						"ack_enabled":   "true",
+						"ack_enabled":   "false",
 						"inputs.#":      "1",
 						"inputs.0":      "#mezmo_http_source.my_source.id",
 						"endpoint":      "https://google.com",


### PR DESCRIPTION
When changing the `ack_enabled` setting, the provider was not including the value in its call to the server. This bug resulted from a lack of proper testing. The test has been fixed.

This commit also updates the `README` for slightly clearer instructions for running the provider locally.

Ref: LOG-19994