### PR TITLE
fix(alert): Update absence alert resource to match API

### DIFF
--- a/docs/resources/absence_alert.md
+++ b/docs/resources/absence_alert.md
@@ -41,7 +41,6 @@ resource "mezmo_absence_alert" "no_data_alert" {
   inputs                  = [mezmo_prometheus_remote_write_source.metrics_source.id]
   name                    = "metrics absence alert"
   event_type              = "metric"
-  operation               = "sum"
   window_duration_minutes = 15
   subject                 = "No data received!"
   severity                = "WARNING"
@@ -65,7 +64,6 @@ resource "mezmo_absence_alert" "no_data_alert" {
 - `ingestion_key` (String) The key required to ingest the alert into Log Analysis
 - `inputs` (List of String) The ids of the input components. This could be the id of a match arm for a route processor, or simply the id of the component.
 - `name` (String) The name of the alert.
-- `operation` (String) Specifies the type of aggregation operation to use with the window type and duration. This value must be `custom` for a Log event type.
 - `pipeline_id` (String) The uuid of the pipeline
 - `subject` (String) The subject line to use when the alert is sent. For a `template` style, surround the field path in double curly braces.
 ```
@@ -78,7 +76,6 @@ resource "mezmo_absence_alert" "no_data_alert" {
 - `description` (String) An optional description describing what the alert is for.
 - `event_timestamp` (String) The path to a field on the event that contains an epoch timestamp value. If an event does not have a timestamp field, events will be associated to the wall clock value when the event is processed. Required for Log event types and disallowed for Metric event types.
 - `group_by` (List of String) When aggregating, group events based on matching values from each of these field paths. Supports nesting via dot-notation. This value is optional for Metric event types, and SHOULD be used for Log event types.
-- `script` (String) A custom JavaScript function that will control the aggregation. At the time of flushing, this aggregation will become the emitted event. This script is required when choosing a `custom` operation.
 - `severity` (String) The severity level of the alert.
 - `style` (String) Configuration for how the alert message will be constructed. For `static`, exact strings will be used. For `template`, the alert subjec and body will allow for placeholders to substitute values from the event.
 - `window_duration_minutes` (Number) The duration of the aggregation window in minutes.

--- a/examples/resources/mezmo_absence_alert/resource.tf
+++ b/examples/resources/mezmo_absence_alert/resource.tf
@@ -26,7 +26,6 @@ resource "mezmo_absence_alert" "no_data_alert" {
   inputs                  = [mezmo_prometheus_remote_write_source.metrics_source.id]
   name                    = "metrics absence alert"
   event_type              = "metric"
-  operation               = "sum"
   window_duration_minutes = 15
   subject                 = "No data received!"
   severity                = "WARNING"

--- a/internal/provider/models/alerts/absence.go
+++ b/internal/provider/models/alerts/absence.go
@@ -22,10 +22,8 @@ type AbsenceAlertModel struct {
 	Description       StringValue `tfsdk:"description" user_config:"true"`
 	EventType         StringValue `tfsdk:"event_type" user_config:"true"`
 	GroupBy           ListValue   `tfsdk:"group_by" user_config:"true"`
-	Operation         StringValue `tfsdk:"operation" user_config:"true"`
 	WindowType        StringValue `tfsdk:"window_type" user_config:"true"`
 	WindowDurationMin Int64Value  `tfsdk:"window_duration_minutes" user_config:"true"`
-	Script            StringValue `tfsdk:"script" user_config:"true"`
 	EventTimestamp    StringValue `tfsdk:"event_timestamp" user_config:"true"`
 	Severity          StringValue `tfsdk:"severity" user_config:"true"`
 	Style             StringValue `tfsdk:"style" user_config:"true"`
@@ -44,9 +42,7 @@ func AbsenceAlertFromModel(plan *AbsenceAlertModel, previousState *AbsenceAlertM
 	dd := diag.Diagnostics{}
 
 	CustomErrorChecks(&CheckedFields{
-		Operation:      plan.Operation,
 		EventType:      plan.EventType,
-		Script:         plan.Script,
 		EventTimestamp: plan.EventTimestamp,
 		GroupBy:        plan.GroupBy,
 	}, &dd)
@@ -74,7 +70,6 @@ func AbsenceAlertFromModel(plan *AbsenceAlertModel, previousState *AbsenceAlertM
 			"evaluation": map[string]any{
 				"alert_type": ALERT_TYPE_ABSENCE, // Required for the API, but hidden from the user here
 				"event_type": plan.EventType.ValueString(),
-				"operation":  Aggregate_Operations[plan.Operation.ValueString()],
 			},
 			"alert_payload": map[string]any{
 				"subject": plan.Subject.ValueString(),
@@ -117,9 +112,6 @@ func AbsenceAlertFromModel(plan *AbsenceAlertModel, previousState *AbsenceAlertM
 	if !plan.EventTimestamp.IsNull() {
 		evaluation["event_timestamp"] = plan.EventTimestamp.ValueString()
 	}
-	if !plan.Script.IsNull() {
-		evaluation["script"] = plan.Script.ValueString()
-	}
 	if !plan.Severity.IsUnknown() {
 		alertPayload["severity"] = plan.Severity.ValueString()
 	}
@@ -158,13 +150,9 @@ func AbsenceAlertToModel(plan *AbsenceAlertModel, component *Alert) {
 	if evaluation["group_by"] != nil {
 		plan.GroupBy = SliceToStringListValue(evaluation["group_by"].([]any))
 	}
-	plan.Operation = NewStringValue(FindKey(Aggregate_Operations, evaluation["operation"].(string)))
 	plan.WindowType = NewStringValue(evaluation["window_type"].(string))
 
 	plan.WindowDurationMin = NewInt64Value(int64(evaluation["window_duration_minutes"].(float64)))
-	if evaluation["script"] != nil {
-		plan.Script = NewStringValue(evaluation["script"].(string))
-	}
 	if evaluation["event_timestamp"] != nil {
 		plan.EventTimestamp = NewStringValue(evaluation["event_timestamp"].(string))
 	}

--- a/internal/provider/models/alerts/change.go
+++ b/internal/provider/models/alerts/change.go
@@ -1,9 +1,11 @@
 package alerts
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
 	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
@@ -43,6 +45,24 @@ var ChangeAlertResourceSchema = schema.Schema{
 			Description: ParentConditionalAttribute(Change_Operator_Labels).Description,
 			Attributes:  ParentConditionalAttribute(Change_Operator_Labels).Attributes,
 		},
+		"operation": schema.StringAttribute{
+			Required: true,
+			Description: "Specifies the type of aggregation operation to use with the window type and duration. " +
+				"This value must be `custom` for a Log event type.",
+			Validators: []validator.String{
+				stringvalidator.OneOf(MapKeys(Aggregate_Operations)...),
+			},
+		},
+		"script": schema.StringAttribute{
+			Optional: true,
+			Validators: []validator.String{
+				stringvalidator.LengthAtLeast(1),
+				stringvalidator.LengthAtMost(5000),
+			},
+			Description: "A custom JavaScript function that will control the aggregation. At the " +
+				"time of flushing, this aggregation will become the emitted event. This script " +
+				"is required when choosing a `custom` operation.",
+		},
 	}),
 }
 
@@ -50,13 +70,15 @@ var ChangeAlertResourceSchema = schema.Schema{
 func ChangeAlertFromModel(plan *ChangeAlertModel, previousState *ChangeAlertModel) (*Alert, diag.Diagnostics) {
 	dd := diag.Diagnostics{}
 
-	CustomErrorChecks(&CheckedFields{
+	checkFields := CheckedFields{
 		Operation:      plan.Operation,
 		EventType:      plan.EventType,
 		Script:         plan.Script,
 		EventTimestamp: plan.EventTimestamp,
 		GroupBy:        plan.GroupBy,
-	}, &dd)
+	}
+	CustomErrorChecks(&checkFields, &dd)
+	OperationAndScriptErrorChecks(&checkFields, &dd)
 
 	if dd.HasError() {
 		return nil, dd

--- a/internal/provider/models/alerts/test/absence_test.go
+++ b/internal/provider/models/alerts/test/absence_test.go
@@ -35,7 +35,6 @@ func TestAbsenceAlert_success(t *testing.T) {
 						inputs = [mezmo_http_source.my_source.id]
 						name = "my absence alert"
 						event_type = "metric"
-						operation = "sum"
 						subject = "Absence Alert"
 						body = "You received a absence alert"
 						ingestion_key = "abc123"
@@ -55,7 +54,6 @@ func TestAbsenceAlert_success(t *testing.T) {
 						"ingestion_key":           "abc123",
 						"body":                    "You received a absence alert",
 						"name":                    "my absence alert",
-						"operation":               "sum",
 						"severity":                "INFO",
 						"style":                   "static",
 						"subject":                 "Absence Alert",
@@ -76,8 +74,6 @@ func TestAbsenceAlert_success(t *testing.T) {
 						name = "updated name"
 						description = "updated description"
 						event_type = "metric"
-						operation = "custom"
-						script = "function myFunc(a, e, m) { return a }"
 						window_type = "sliding"
 						window_duration_minutes = 10
 						group_by = [".other"]
@@ -95,8 +91,6 @@ func TestAbsenceAlert_success(t *testing.T) {
 						"group_by.0":              ".other",
 						"body":                    "updated body",
 						"name":                    "updated name",
-						"operation":               "custom",
-						"script":                  "function myFunc(a, e, m) { return a }",
 						"severity":                "WARNING",
 						"subject":                 "updated subject",
 						"window_duration_minutes": "10",
@@ -115,8 +109,6 @@ func TestAbsenceAlert_success(t *testing.T) {
 						inputs = [mezmo_http_source.my_source.id]
 						name = "my absence alert"
 						event_type = "log"
-						operation = "custom"
-						script = "function myFunc(a, e, m) { return a }"
 						event_timestamp = ".timestamp"
 						group_by = [".name", ".namespace", ".tags"]
 						subject = "Absence Alert for Log event"
@@ -142,8 +134,6 @@ func TestAbsenceAlert_success(t *testing.T) {
 						"group_by.2":              ".tags",
 						"ingestion_key":           "abc123",
 						"name":                    "my absence alert",
-						"operation":               "custom",
-						"script":                  "function myFunc(a, e, m) { return a }",
 						"severity":                "INFO",
 						"style":                   "static",
 						"subject":                 "Absence Alert for Log event",
@@ -179,7 +169,6 @@ func TestAbsenceAlert_schema_validation_errors(t *testing.T) {
 						inputs = [mezmo_http_source.my_source.id]
 						name = "my bad absence alert"
 						event_type = "metric"
-						operation = "sum"
 						group_by = [".timestamp"]
 						conditional = {
 							expressions = [

--- a/pkg/resources/testdata/alerts/absence.json
+++ b/pkg/resources/testdata/alerts/absence.json
@@ -20,8 +20,6 @@
       "alert_type": "absence",
       "event_timestamp": ".timestamp",
       "event_type": "log",
-      "operation": "CUSTOM",
-      "script": "function myFunc(a, e, m) { return a }",
       "window_duration_minutes": 5,
       "window_type": "tumbling"
     },


### PR DESCRIPTION
The absence alert API schema no longer supports defining the `operation` or `script` fields. This commit updates the provider to match that requirement.

Ref: LOG-20049