### PR TITLE
fix: Use goreleaser v1.26.2 instead of latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-snapshot-binary:
 	-e GOARCH \
 	-v $(PWD):/opt/app \
 	-w /opt/app \
-	goreleaser/goreleaser \
+	goreleaser/goreleaser:v1.26.2 \
 		build \
 		--single-target \
 		--snapshot \


### PR DESCRIPTION
latest currently is v2, which is a breaking release.

refs: LOG-20051
