### PR TITLE
fix: bump goreleaser@2.0.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2 # Requires goreleaser 2.0
+
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -41,7 +43,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this in a GitHub action or some other automated pipeline, you 
+      # if you are using this in a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"
@@ -57,4 +59,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-snapshot-binary:
 	-e GOARCH \
 	-v $(PWD):/opt/app \
 	-w /opt/app \
-	goreleaser/goreleaser:v1.26.2 \
+	goreleaser/goreleaser \
 		build \
 		--single-target \
 		--snapshot \


### PR DESCRIPTION
`goreleaser` just did a major release, eliminating the ability to install previous versions. This means all users will have to upgrade it for deployment. This commit fixes the configuration file according to: https://carlosbecker.com/posts/goreleaser-v2/

Ref: LOG-20064