### PR TITLE
fix(docs): Change provider version to 2.0.0 where needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ website/node_modules
 *.backup
 ./*.tfstate
 .terraform/
+.terraform.lock.hcl
 *.log
 *.bak
 *~

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build-snapshot-binary:
 	-e GOARCH \
 	-v $(PWD):/opt/app \
 	-w /opt/app \
-	goreleaser/goreleaser \
+	goreleaser/goreleaser:v2.0.0 \
 		build \
 		--single-target \
 		--snapshot \
@@ -57,7 +57,8 @@ build-test-example-binary: set-test-example-target build-snapshot-binary
 examples: $(wildcard examples/*/*/)
 
 examples/%: build-test-example-binary
-	docker run \
+	@echo $@
+	@docker run \
 		-v $(PWD):/opt/app \
 		-v $(PWD)/$@:/opt/example/$@ \
 		-e TF_CLI_CONFIG_FILE=/opt/app/tf-dev-config \

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     mezmo = {
       source  = "mezmo/mezmo"
-      version = "~> 1.0"
+      version = "~> 2.0.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mezmo = {
       source  = "mezmo/mezmo"
-      version = "~> 1.0"
+      version = "~> 2.0.0"
     }
   }
 }


### PR DESCRIPTION
**fix(docs): Change provider version to 2.0.0 where needed**

The example for the provider itself specifies the version. That needs to
be upgraded to our latest major revision, or some components won't work.
Publish this release so that the Terraform registry docs are correct
with that version in the examples.

Ref: LOG-20006

---

**fix(examples): Specify goreleaser version**

When running `make examples` we should specify the version since a
recent upgrade forced changes to our configuration that are not backward
compatible. Also, silence the `@docker` command, but `@echo` the example
being validated.

Ref: LOG-20006