### PR TITLE
fix(route): Increase the character limit for route labels

### DIFF
--- a/docs/resources/route_processor.md
+++ b/docs/resources/route_processor.md
@@ -219,7 +219,7 @@ resource "mezmo_blackhole_destination" "destination3" {
 
 Required:
 
-- `label` (String) A label for the expresion group
+- `label` (String) A label for the expression group
 
 Optional:
 

--- a/internal/provider/models/processors/route.go
+++ b/internal/provider/models/processors/route.go
@@ -41,10 +41,10 @@ var RouteProcessorResourceSchema = schema.Schema{
 				Attributes: ExtendSchemaAttributes(ParentConditionalAttribute(Non_Change_Operator_Labels).Attributes, map[string]schema.Attribute{
 					"label": schema.StringAttribute{
 						Required:    true,
-						Description: "A label for the expresion group",
+						Description: "A label for the expression group",
 						Validators: []validator.String{
 							stringvalidator.LengthAtLeast(1),
-							stringvalidator.LengthAtMost(20),
+							stringvalidator.LengthAtMost(255),
 						},
 					},
 					"output_name": schema.StringAttribute{

--- a/internal/provider/models/processors/test/route_test.go
+++ b/internal/provider/models/processors/test/route_test.go
@@ -102,6 +102,28 @@ func TestRouteProcessor(t *testing.T) {
 				ExpectError: regexp.MustCompile("(?s)Inappropriate value for attribute \"conditionals\": element 1: attribute.*\"label\" is required"),
 			},
 
+			// Error: label length too long
+			{
+				Config: GetCachedConfig(cacheKey) + `
+					resource "mezmo_route_processor" "my_processor" {
+						pipeline_id = mezmo_pipeline.test_parent.id
+
+						conditionals = [
+							{
+								expressions = [
+									{
+										field = ".status"
+										operator = "equal"
+										value_number = 200
+									}
+								]
+								label = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+							}
+						]
+					}`,
+				ExpectError: regexp.MustCompile("(?s).*label string length must be at most 255.*"),
+			},
+
 			// Error: value_string and value_number are mutually exclusive
 			{
 				Config: GetCachedConfig(cacheKey) + `


### PR DESCRIPTION
The WebUI allows for 255 characters so the provider should allow the same. This change bumps the limit from 20 characters on the label length to 255 and adds a test to verify that it is not exceeded.

Ref: LOG-20068