### PR TITLE
fix(resources): `shared_source` description should be optional

### DIFF
--- a/docs/resources/shared_source.md
+++ b/docs/resources/shared_source.md
@@ -49,9 +49,12 @@ resource "mezmo_shared_source" "http" {
 
 ### Required
 
-- `description` (String) Details describing the shared source.
 - `title` (String) A descriptive name for the shared source.
 - `type` (String) The type of source that should be shared. This is typically the name of the source componenet, e.g. `kinesis-firehose`. The source must be a "push source", thus pull sources cannot be shared and will result in an error.
+
+### Optional
+
+- `description` (String) Details describing the shared source.
 
 ### Read-Only
 

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -62,7 +62,7 @@ type AccessKey struct {
 type SharedSource struct {
 	Id          string `json:"id"`
 	Title       string `json:"title"`
-	Description string `json:"description"`
+	Description string `json:"description,omitempty"`
 	Type        string `json:"type"`
 }
 

--- a/internal/provider/models/shared_source.go
+++ b/internal/provider/models/shared_source.go
@@ -49,7 +49,7 @@ func SharedSourceResourceSchema() schema.Schema {
 			},
 			"description": schema.StringAttribute{
 				Description: "Details describing the shared source.",
-				Required:    true,
+				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 				},
@@ -73,12 +73,14 @@ func SharedSourceResourceSchema() schema.Schema {
 // From terraform schema/model to a struct for sending to the API
 func SharedSourceFromModel(plan *SharedSourceResourceModel) *SharedSource {
 	source := SharedSource{
-		Title:       plan.Title.ValueString(),
-		Description: plan.Description.ValueString(),
-		Type:        plan.Type.ValueString(),
+		Title: plan.Title.ValueString(),
+		Type:  plan.Type.ValueString(),
 	}
 	if !plan.Id.IsUnknown() {
 		source.Id = plan.Id.ValueString()
+	}
+	if !plan.Description.IsNull() {
+		source.Description = plan.Description.ValueString()
 	}
 	return &source
 }
@@ -87,6 +89,8 @@ func SharedSourceFromModel(plan *SharedSourceResourceModel) *SharedSource {
 func SharedSourceToModel(plan *SharedSourceResourceModel, source *SharedSource) {
 	plan.Id = NewStringValue(source.Id)
 	plan.Title = NewStringValue(source.Title)
-	plan.Description = NewStringValue(source.Description)
 	plan.Type = NewStringValue(source.Type)
+	if source.Description != "" {
+		plan.Description = NewStringValue(source.Description)
+	}
 }

--- a/internal/provider/shared_source_resource_test.go
+++ b/internal/provider/shared_source_resource_test.go
@@ -27,7 +27,6 @@ func TestSharedSourceResource(t *testing.T) {
 					}`) + `
 					resource "mezmo_shared_source" "my_source" {
 						title = "HTTP Shared"
-            description = "This source can be shared across pipelines"
             type = "http"
           }
 				`,
@@ -35,9 +34,8 @@ func TestSharedSourceResource(t *testing.T) {
 					resource.TestMatchOutput("shared_source_key", regexp.MustCompile(`\w+`)),
 					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "id", IDRegex),
 					StateHasExpectedValues("mezmo_shared_source.my_source", map[string]any{
-						"title":       "HTTP Shared",
-						"description": "This source can be shared across pipelines",
-						"type":        "http",
+						"title": "HTTP Shared",
+						"type":  "http",
 					}),
 				),
 			},
@@ -64,7 +62,6 @@ func TestSharedSourceResource(t *testing.T) {
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_shared_source" "my_source" {
 						title = "updated title"
-            description = "updated description"
 						type = "kinesis-firehose"
           }
 				`,
@@ -73,9 +70,8 @@ func TestSharedSourceResource(t *testing.T) {
 					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "id", IDRegex),
 					resource.TestCheckResourceAttrPair("mezmo_access_key.shared", "source_id", "mezmo_shared_source.my_source", "id"),
 					StateHasExpectedValues("mezmo_shared_source.my_source", map[string]any{
-						"title":       "updated title",
-						"description": "updated description",
-						"type":        "kinesis-firehose",
+						"title": "updated title",
+						"type":  "kinesis-firehose",
 					}),
 				),
 			},


### PR DESCRIPTION
The `description` field for the shared_source resource should have been optional, not required.

Ref: LOG-20092