### PR TITLE
fix(alert): add sensitive flag to ingestion key field

### DIFF
--- a/internal/provider/models/alerts/base_model.go
+++ b/internal/provider/models/alerts/base_model.go
@@ -169,7 +169,8 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 			"```\n" + `{{"{{.my_field}} had a count of {{metadata.aggregate.event_count}}"}}` + "\n```",
 	},
 	"ingestion_key": schema.StringAttribute{
-		Required: true,
+		Required:  true,
+		Sensitive: true,
 		Validators: []validator.String{
 			stringvalidator.LengthAtLeast(1),
 		},


### PR DESCRIPTION
This value includes the Mezmo log analysis key and should be treated as a sensitive credential value.

Ref: LOG-20098