### PR TITLE
fix(alert): fix handling of component_id and component_kind

### DIFF
--- a/internal/provider/models/alerts/absence.go
+++ b/internal/provider/models/alerts/absence.go
@@ -125,6 +125,8 @@ func AbsenceAlertFromModel(plan *AbsenceAlertModel, previousState *AbsenceAlertM
 // From an API response to a terraform model
 func AbsenceAlertToModel(plan *AbsenceAlertModel, component *Alert) {
 	plan.Id = NewStringValue(component.Id)
+	plan.ComponentKind = NewStringValue(component.ComponentKind)
+	plan.ComponentId = NewStringValue(component.ComponentId)
 	plan.Active = NewBoolValue(component.Active)
 	if component.Inputs != nil {
 		inputs := make([]attr.Value, 0)

--- a/internal/provider/models/alerts/change.go
+++ b/internal/provider/models/alerts/change.go
@@ -163,6 +163,8 @@ func ChangeAlertFromModel(plan *ChangeAlertModel, previousState *ChangeAlertMode
 // From an API response to a terraform model
 func ChangeAlertToModel(plan *ChangeAlertModel, component *Alert) {
 	plan.Id = NewStringValue(component.Id)
+	plan.ComponentKind = NewStringValue(component.ComponentKind)
+	plan.ComponentId = NewStringValue(component.ComponentId)
 	plan.Active = NewBoolValue(component.Active)
 	if component.Inputs != nil {
 		inputs := make([]attr.Value, 0)

--- a/internal/provider/models/alerts/threshold.go
+++ b/internal/provider/models/alerts/threshold.go
@@ -163,6 +163,8 @@ func ThresholdAlertFromModel(plan *ThresholdAlertModel, previousState *Threshold
 // From an API response to a terraform model
 func ThresholdAlertToModel(plan *ThresholdAlertModel, component *Alert) {
 	plan.Id = NewStringValue(component.Id)
+	plan.ComponentKind = NewStringValue(component.ComponentKind)
+	plan.ComponentId = NewStringValue(component.ComponentId)
 	plan.Active = NewBoolValue(component.Active)
 	if component.Inputs != nil {
 		inputs := make([]attr.Value, 0)


### PR DESCRIPTION
Updated functions that convert from an alert API response to the TF
models so they actually set the `component_id` and `component_kind`
fields.

Ref: LOG-20106