### PR TITLE
fix(test): use correct image/version for tsdb

### DIFF
--- a/compose/base.yml
+++ b/compose/base.yml
@@ -3,8 +3,7 @@ version: '2.4'
 services:
 
   timescaledb-service:
-    image: timescale/timescaledb:latest-pg14
-
+    image: timescale/timescaledb:2.8.1-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
@@ -20,7 +19,7 @@ services:
       retries: 50
 
   timescaledb-metrics:
-    image: timescale/timescaledb:latest-pg14
+    image: timescale/timescaledb:2.8.1-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/internal/provider/models/processors/test/aggregate_v2_test.go
+++ b/internal/provider/models/processors/test/aggregate_v2_test.go
@@ -53,7 +53,7 @@ func TestAggregateV2Processor(t *testing.T) {
 						"window_type":     "tumbling",
 						"interval":        "3600",
 						"operation":       "sum",
-						"event_timestamp": ".timestamp",
+						"event_timestamp": "timestamp",
 					}),
 					StateDoesNotHaveFields("mezmo_aggregate_v2_processor.my_processor", []string{"script"}),
 				),


### PR DESCRIPTION
This fixes an inconsistency that causes the service to fail to start.

Ref: LOG-20221