### PR TITLE
ci: fix connection refused

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye as test
+FROM golang:1.21-bullseye as test
 
 WORKDIR /build
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-unit:
 	go test ./...
 
 .PHONY: test-acceptance
-test:
+test-acceptance:
 	docker-compose -f compose/base.yml pull && docker-compose \
 	-p terraform-provider-mezmo-$(BUILD_TAG) \
 	-f compose/base.yml -f compose/test.yml \
@@ -27,7 +27,7 @@ test:
 
 .PHONY: test-docs
 test-docs: generate-doc
-	@git diff --exit-code
+	git diff --exit-code -- docs/
 
 .PHONY: start
 start:
@@ -81,10 +81,8 @@ examples/%: build-test-example-binary
 		exit $${PIPESTATUS[0]}
 
 .PHONY: local-test
-ENV := $(PWD)/env/local.env
-include $(ENV)
-export
 local-test:
+	@set -a; . $(PWD)/env/local.env; set +a; \
 	go test -v -count=1 ./...
 
 .PHONY: lint

--- a/internal/provider/models/processors/test/aggregate_v2_test.go
+++ b/internal/provider/models/processors/test/aggregate_v2_test.go
@@ -266,7 +266,7 @@ func TestAccAggregateV2Processor(t *testing.T) {
 							"window_min": float64(5),
 						},
 						"evaluate":        map[string]any{"operation": string("SUM")},
-						"event_timestamp": string(".timestamp"),
+						"event_timestamp": string("timestamp"),
 					}),
 				),
 			},

--- a/internal/provider/models/processors/test/unroll_test.go
+++ b/internal/provider/models/processors/test/unroll_test.go
@@ -118,10 +118,10 @@ func TestAccUnrollProcessor(t *testing.T) {
 				Config: GetCachedConfig(cacheKey) + `
 				resource "mezmo_unroll_processor" "my_processor" {
 					pipeline_id = mezmo_pipeline.test_parent.id
-					inputs = []
+					inputs = [mezmo_http_source.my_source.id]
 					field = "not-a-valid-field"
 				}`,
-				ExpectError: regexp.MustCompile("match pattern"),
+				ExpectError: regexp.MustCompile("valid data access syntax"),
 			},
 
 			// confirm manually deleted resources are recreated


### PR DESCRIPTION
The env variables was loaded for all targets causing the test-unit to run the acceptance tests as well.

Also make the docs test to only check the docs folder.

Ref: LOG-19481