### PR TITLE
fix(examples): New alert payload needs examples

### DIFF
--- a/docs/resources/absence_alert.md
+++ b/docs/resources/absence_alert.md
@@ -97,9 +97,9 @@ Optional:
 
 - `body` (String) Additional information to be added to the message (Log Analysis).
 - `event_action` (String) The event action to use (PagerDuty).
-- `ingestion_key` (String) The ingestion key for the service (Log Analysis).
+- `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
 - `message_text` (String) The text value of the notification message (Slack, Webhook).
-- `routing_key` (String) The service's routing key (PagerDuty).
+- `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
 - `severity` (String) The severity level of the alert (PagerDuty, Log Analysis).
 - `source` (String) The source of the alert (PagerDuty).
 - `subject` (String) The main subject line of the message (Log Analysis).

--- a/docs/resources/change_alert.md
+++ b/docs/resources/change_alert.md
@@ -120,9 +120,9 @@ Optional:
 
 - `body` (String) Additional information to be added to the message (Log Analysis).
 - `event_action` (String) The event action to use (PagerDuty).
-- `ingestion_key` (String) The ingestion key for the service (Log Analysis).
+- `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
 - `message_text` (String) The text value of the notification message (Slack, Webhook).
-- `routing_key` (String) The service's routing key (PagerDuty).
+- `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
 - `severity` (String) The severity level of the alert (PagerDuty, Log Analysis).
 - `source` (String) The source of the alert (PagerDuty).
 - `subject` (String) The main subject line of the message (Log Analysis).

--- a/docs/resources/threshold_alert.md
+++ b/docs/resources/threshold_alert.md
@@ -120,9 +120,9 @@ Optional:
 
 - `body` (String) Additional information to be added to the message (Log Analysis).
 - `event_action` (String) The event action to use (PagerDuty).
-- `ingestion_key` (String) The ingestion key for the service (Log Analysis).
+- `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
 - `message_text` (String) The text value of the notification message (Slack, Webhook).
-- `routing_key` (String) The service's routing key (PagerDuty).
+- `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
 - `severity` (String) The severity level of the alert (PagerDuty, Log Analysis).
 - `source` (String) The source of the alert (PagerDuty).
 - `subject` (String) The main subject line of the message (Log Analysis).

--- a/examples/resources/mezmo_absence_alert/resource.tf
+++ b/examples/resources/mezmo_absence_alert/resource.tf
@@ -27,8 +27,13 @@ resource "mezmo_absence_alert" "no_data_alert" {
   name                    = "metrics absence alert"
   event_type              = "metric"
   window_duration_minutes = 15
-  subject                 = "No data received!"
-  severity                = "WARNING"
-  body                    = "There has been no metrics data recieved in the last 15 minutes!"
-  ingestion_key           = "abc123"
+  alert_payload = {
+    service = {
+      name          = "log_analysis"
+      subject       = "No data received!"
+      severity      = "WARNING"
+      body          = "There has been no metrics data recieved in the last 15 minutes!"
+      ingestion_key = "abc123"
+    }
+  }
 }

--- a/examples/resources/mezmo_change_alert/resource.tf
+++ b/examples/resources/mezmo_change_alert/resource.tf
@@ -48,8 +48,16 @@ resource "mezmo_change_alert" "order_spike" {
   }
   window_type             = "sliding"
   window_duration_minutes = 15
-  subject                 = "Spike in ordering!"
-  severity                = "WARNING"
-  body                    = "There has been a > 20% increase in orders over the last 15 minutes. Check application scaling."
-  ingestion_key           = "abc123"
+
+  alert_payload = {
+    service = {
+      name         = "webhook"
+      uri          = "https://example.com/my_webhook"
+      message_text = "There has been a > 20% increase in orders ({{.total_orders}}) over the last 15 minutes. Check application scaling."
+    }
+    throttling = {
+      window_secs = 3600
+      threshold   = 2
+    }
+  }
 }

--- a/examples/resources/mezmo_threshold_alert/resource.tf
+++ b/examples/resources/mezmo_threshold_alert/resource.tf
@@ -48,8 +48,19 @@ resource "mezmo_threshold_alert" "order_count" {
   }
   window_type             = "tumbling"
   window_duration_minutes = 60
-  subject                 = "Lots of orders coming in the last hour!"
-  severity                = "WARNING"
-  body                    = "Check to make sure there are no errors in pricing, and no unexpected special offers were released."
-  ingestion_key           = "abc123"
+  alert_payload = {
+    service = {
+      name         = "pager_duty"
+      uri          = "https://example.com/pager_duty_api"
+      source       = "{{.my_source}}"
+      routing_key  = "abc123"
+      severity     = "CRITICAL"
+      event_action = "trigger"
+      summary      = "Check to make sure there are no errors in pricing, and no unexpected special offers were released."
+    }
+    throttling = {
+      window_secs = 3600
+      threshold   = 1
+    }
+  }
 }

--- a/internal/provider/models/alerts/base_model.go
+++ b/internal/provider/models/alerts/base_model.go
@@ -166,6 +166,7 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 					},
 					"routing_key": schema.StringAttribute{
 						Optional:    true,
+						Sensitive:   true,
 						Description: "The service's routing key (PagerDuty).",
 					},
 					"event_action": schema.StringAttribute{
@@ -189,6 +190,7 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 					},
 					"ingestion_key": schema.StringAttribute{
 						Optional:    true,
+						Sensitive:   true,
 						Description: "The ingestion key for the service (Log Analysis).",
 					},
 				},


### PR DESCRIPTION
**fix(examples): New alert payload needs examples**

The examples were not updated after the alert payload changed.

Ref: LOG-20284

---

**fix(alerts): Mark sensitive fields after payload shape change**

The shape of the payload changed, and the `ingestion_key` was
re-defined, but not marked as `Sensitive`. This breaks the import/export
tool, and it should be marked sensitive anyway.

Ref: LOG-20284