### PR TITLE
chore(ci): Split test types into own stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,9 +92,19 @@ pipeline {
 
     stage('Test') {
       parallel {
-        stage('Integration Tests') {
+        stage('Documentation') {
           steps {
-            sh 'make test'
+            sh 'make test-docs'
+          }
+        }
+        stage('Unit') {
+          steps {
+            sh 'make test-unit'
+          }
+        }
+        stage('Integration') {
+          steps {
+            sh 'make test-acceptance'
           }
           post {
             always {

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ build:
 generate-doc:
 	go generate
 
+# If you add a new target that `test` calls, you'll need to add it to CI
+# explicitly.
 .PHONY: test
 test: test-docs test-unit test-acceptance
 


### PR DESCRIPTION
This change splits the 3 test types (doc, unit, integration) into their
own stages for better parallelization and better visibility into which
type of test fails.

Ref: LOG-20344
