### PR TITLE
feat(destinations): Add webhook options to alerts

### DIFF
--- a/docs/resources/change_alert.md
+++ b/docs/resources/change_alert.md
@@ -126,8 +126,10 @@ Required:
 
 Optional:
 
+- `auth` (Attributes) Configures HTTP authentication (Webhook). (see [below for nested schema](#nestedatt--alert_payload--service--auth))
 - `body` (String) Additional information to be added to the message (Log Analysis).
 - `event_action` (String) The event action to use (PagerDuty).
+- `headers` (Map of String) Optional key/val request headers (Webhook).
 - `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
 - `message_text` (String) The text value of the notification message (Slack, Webhook).
 - `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
@@ -136,6 +138,20 @@ Optional:
 - `subject` (String) The main subject line of the message (Log Analysis).
 - `summary` (String) Summarize the alert details (PagerDuty).
 - `uri` (String) The URI of the service (Slack, PagerDuty, Webhook).
+
+<a id="nestedatt--alert_payload--service--auth"></a>
+### Nested Schema for `alert_payload.service.auth`
+
+Required:
+
+- `strategy` (String)
+
+Optional:
+
+- `password` (String, Sensitive)
+- `token` (String, Sensitive)
+- `user` (String)
+
 
 
 <a id="nestedatt--alert_payload--throttling"></a>

--- a/docs/resources/threshold_alert.md
+++ b/docs/resources/threshold_alert.md
@@ -129,8 +129,10 @@ Required:
 
 Optional:
 
+- `auth` (Attributes) Configures HTTP authentication (Webhook). (see [below for nested schema](#nestedatt--alert_payload--service--auth))
 - `body` (String) Additional information to be added to the message (Log Analysis).
 - `event_action` (String) The event action to use (PagerDuty).
+- `headers` (Map of String) Optional key/val request headers (Webhook).
 - `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
 - `message_text` (String) The text value of the notification message (Slack, Webhook).
 - `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
@@ -139,6 +141,20 @@ Optional:
 - `subject` (String) The main subject line of the message (Log Analysis).
 - `summary` (String) Summarize the alert details (PagerDuty).
 - `uri` (String) The URI of the service (Slack, PagerDuty, Webhook).
+
+<a id="nestedatt--alert_payload--service--auth"></a>
+### Nested Schema for `alert_payload.service.auth`
+
+Required:
+
+- `strategy` (String)
+
+Optional:
+
+- `password` (String, Sensitive)
+- `token` (String, Sensitive)
+- `user` (String)
+
 
 
 <a id="nestedatt--alert_payload--throttling"></a>

--- a/examples/resources/mezmo_absence_alert/resource.tf
+++ b/examples/resources/mezmo_absence_alert/resource.tf
@@ -19,7 +19,7 @@ resource "mezmo_prometheus_remote_write_source" "metrics_source" {
   title       = "My Prometheus Remote Write source"
   description = "This receives data from prometheus"
 }
-resource "mezmo_absence_alert" "no_data_alert" {
+resource "mezmo_absence_alert" "no_data_alert_log_analysis" {
   pipeline_id             = mezmo_pipeline.my_pipeline.id
   component_kind          = "source"
   component_id            = mezmo_prometheus_remote_write_source.metrics_source.id
@@ -34,6 +34,29 @@ resource "mezmo_absence_alert" "no_data_alert" {
       severity      = "WARNING"
       body          = "There has been no metrics data received in the last 15 minutes!"
       ingestion_key = "abc123"
+    }
+  }
+}
+resource "mezmo_absence_alert" "no_data_alert_webhook" {
+  pipeline_id             = mezmo_pipeline.my_pipeline.id
+  component_kind          = "source"
+  component_id            = mezmo_prometheus_remote_write_source.metrics_source.id
+  inputs                  = [mezmo_prometheus_remote_write_source.metrics_source.id]
+  name                    = "metrics absence alert"
+  event_type              = "metric"
+  window_duration_minutes = 15
+  alert_payload = {
+    service = {
+      name         = "webhook"
+      uri          = "http://example.com/my_webhook"
+      message_text = "There was an absence alert!"
+      auth = {
+        strategy = "bearer"
+        token    = "abc123"
+      }
+      headers = {
+        "x-my-header" = "header_value"
+      }
     }
   }
 }


### PR DESCRIPTION
When using a webhook alert destination, the resource now supports authentication types and user-defined request headers.

Ref: LOG-20388