### PR TITLE
chore(ci): Add junit reporting to unit tests for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,13 @@ pipeline {
         }
         stage('Unit') {
           steps {
-            sh 'make test-unit'
+            sh 'command -v go-junit-report || go install github.com/jstemmer/go-junit-report/v2@latest'
+            sh 'make test-unit 2>&1 | go-junit-report -iocopy -set-exit-code -out unit-results.xml'
+          }
+          post {
+            always {
+              junit testResults: 'unit-results.xml'
+            }
           }
         }
         stage('Integration') {

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test: test-docs test-unit test-acceptance
 
 .PHONY: test-unit
 test-unit:
-	go test ./...
+	@go test -v ./...
 
 .PHONY: test-acceptance
 test-acceptance:


### PR DESCRIPTION
This change updates the `Jenkinsfile` to create a junit report for the
"Unit" stage.

Refs: LOG-20396
