### PR TITLE
fix(docs): Update alert descriptions

### DIFF
--- a/docs/resources/absence_alert.md
+++ b/docs/resources/absence_alert.md
@@ -83,7 +83,7 @@ resource "mezmo_absence_alert" "no_data_alert_webhook" {
 
 ### Required
 
-- `alert_payload` (Attributes) Configure where the alert will be sent, including choosing a service and throttling options. All options for the chosen `service` will be required. All text fields support templating. (see [below for nested schema](#nestedatt--alert_payload))
+- `alert_payload` (Attributes) Configure where the alert will be sent, including choosing a service and throttling options. All options for the chosen `service` will be required. All text fields support templating, e.g. `{{.my_field}}` as long as those values can be coerced to a string. For more information, see [our documentation](https://docs.mezmo.com/telemetry-pipelines/syntax-for-editing-pipeline-component-configuration-values#templates). (see [below for nested schema](#nestedatt--alert_payload))
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `event_type` (String) The type of event is either a Log event or a Metric event.
@@ -129,7 +129,7 @@ Optional:
 - `event_action` (String) The event action to use (PagerDuty).
 - `headers` (Map of String) Optional key/val request headers (Webhook).
 - `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
-- `message_text` (String) The text value of the notification message (Slack, Webhook).
+- `message_text` (String) The text value of the notification message (Slack, Webhook). When using a Webhook, this value may be a text string or stringified JSON. If the Webhook's message can be parsed as JSON, it will be sent as such.
 - `method` (String) The HTTP method to use for the destination (Webhook, default is `post`).
 - `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
 - `severity` (String) The severity level of the alert (PagerDuty, Log Analysis).
@@ -143,13 +143,13 @@ Optional:
 
 Required:
 
-- `strategy` (String)
+- `strategy` (String) Choose basic or token-based authentication.
 
 Optional:
 
-- `password` (String, Sensitive)
-- `token` (String, Sensitive)
-- `user` (String)
+- `password` (String, Sensitive) The basic authentication password.
+- `token` (String, Sensitive) The bearer token.
+- `user` (String) The basic authentication user.
 
 
 

--- a/docs/resources/change_alert.md
+++ b/docs/resources/change_alert.md
@@ -82,7 +82,7 @@ resource "mezmo_change_alert" "order_spike" {
 
 ### Required
 
-- `alert_payload` (Attributes) Configure where the alert will be sent, including choosing a service and throttling options. All options for the chosen `service` will be required. All text fields support templating. (see [below for nested schema](#nestedatt--alert_payload))
+- `alert_payload` (Attributes) Configure where the alert will be sent, including choosing a service and throttling options. All options for the chosen `service` will be required. All text fields support templating, e.g. `{{.my_field}}` as long as those values can be coerced to a string. For more information, see [our documentation](https://docs.mezmo.com/telemetry-pipelines/syntax-for-editing-pipeline-component-configuration-values#templates). (see [below for nested schema](#nestedatt--alert_payload))
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `conditional` (Attributes) A group of expressions (optionally nested) joined by a logical operator (see [below for nested schema](#nestedatt--conditional))
@@ -131,7 +131,7 @@ Optional:
 - `event_action` (String) The event action to use (PagerDuty).
 - `headers` (Map of String) Optional key/val request headers (Webhook).
 - `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
-- `message_text` (String) The text value of the notification message (Slack, Webhook).
+- `message_text` (String) The text value of the notification message (Slack, Webhook). When using a Webhook, this value may be a text string or stringified JSON. If the Webhook's message can be parsed as JSON, it will be sent as such.
 - `method` (String) The HTTP method to use for the destination (Webhook, default is `post`).
 - `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
 - `severity` (String) The severity level of the alert (PagerDuty, Log Analysis).
@@ -145,13 +145,13 @@ Optional:
 
 Required:
 
-- `strategy` (String)
+- `strategy` (String) Choose basic or token-based authentication.
 
 Optional:
 
-- `password` (String, Sensitive)
-- `token` (String, Sensitive)
-- `user` (String)
+- `password` (String, Sensitive) The basic authentication password.
+- `token` (String, Sensitive) The bearer token.
+- `user` (String) The basic authentication user.
 
 
 

--- a/docs/resources/threshold_alert.md
+++ b/docs/resources/threshold_alert.md
@@ -85,7 +85,7 @@ resource "mezmo_threshold_alert" "order_count" {
 
 ### Required
 
-- `alert_payload` (Attributes) Configure where the alert will be sent, including choosing a service and throttling options. All options for the chosen `service` will be required. All text fields support templating. (see [below for nested schema](#nestedatt--alert_payload))
+- `alert_payload` (Attributes) Configure where the alert will be sent, including choosing a service and throttling options. All options for the chosen `service` will be required. All text fields support templating, e.g. `{{.my_field}}` as long as those values can be coerced to a string. For more information, see [our documentation](https://docs.mezmo.com/telemetry-pipelines/syntax-for-editing-pipeline-component-configuration-values#templates). (see [below for nested schema](#nestedatt--alert_payload))
 - `component_id` (String) The uuid of the component that the alert is attached to
 - `component_kind` (String) The kind of component that the alert is attached to
 - `conditional` (Attributes) A group of expressions (optionally nested) joined by a logical operator (see [below for nested schema](#nestedatt--conditional))
@@ -134,7 +134,7 @@ Optional:
 - `event_action` (String) The event action to use (PagerDuty).
 - `headers` (Map of String) Optional key/val request headers (Webhook).
 - `ingestion_key` (String, Sensitive) The ingestion key for the service (Log Analysis).
-- `message_text` (String) The text value of the notification message (Slack, Webhook).
+- `message_text` (String) The text value of the notification message (Slack, Webhook). When using a Webhook, this value may be a text string or stringified JSON. If the Webhook's message can be parsed as JSON, it will be sent as such.
 - `method` (String) The HTTP method to use for the destination (Webhook, default is `post`).
 - `routing_key` (String, Sensitive) The service's routing key (PagerDuty).
 - `severity` (String) The severity level of the alert (PagerDuty, Log Analysis).
@@ -148,13 +148,13 @@ Optional:
 
 Required:
 
-- `strategy` (String)
+- `strategy` (String) Choose basic or token-based authentication.
 
 Optional:
 
-- `password` (String, Sensitive)
-- `token` (String, Sensitive)
-- `user` (String)
+- `password` (String, Sensitive) The basic authentication password.
+- `token` (String, Sensitive) The bearer token.
+- `user` (String) The basic authentication user.
 
 
 

--- a/internal/provider/models/alerts/base_model.go
+++ b/internal/provider/models/alerts/base_model.go
@@ -135,9 +135,11 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 	},
 	"alert_payload": schema.SingleNestedAttribute{
 		Required: true,
-		Description: "Configure where the alert will be sent, including choosing a service " +
+		MarkdownDescription: "Configure where the alert will be sent, including choosing a service " +
 			"and throttling options. All options for the chosen `service` will be required. " +
-			"All text fields support templating.",
+			"All text fields support templating, e.g. `{{.my_field}}` as long as those values " +
+			"can be coerced to a string. For more information, see " +
+			"[our documentation](https://docs.mezmo.com/telemetry-pipelines/syntax-for-editing-pipeline-component-configuration-values#templates).",
 		Attributes: map[string]schema.Attribute{
 			"service": schema.SingleNestedAttribute{
 				Required:    true,
@@ -155,8 +157,11 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 						Description: "The URI of the service (Slack, PagerDuty, Webhook).",
 					},
 					"message_text": schema.StringAttribute{
-						Optional:    true,
-						Description: "The text value of the notification message (Slack, Webhook).",
+						Optional: true,
+						Description: "The text value of the notification message (Slack, Webhook). " +
+							"When using a Webhook, this value may be a text string or " +
+							"stringified JSON. If the Webhook's message can be parsed as JSON, it will be " +
+							"sent as such.",
 					},
 					"summary": schema.StringAttribute{
 						Optional:    true,
@@ -200,22 +205,26 @@ var baseAlertSchemaAttributes = SchemaAttributes{
 						Description: "Configures HTTP authentication (Webhook).",
 						Attributes: map[string]schema.Attribute{
 							"strategy": schema.StringAttribute{
-								Required:   true,
-								Validators: []validator.String{stringvalidator.OneOf("basic", "bearer")},
+								Required:    true,
+								Description: "Choose basic or token-based authentication.",
+								Validators:  []validator.String{stringvalidator.OneOf("basic", "bearer")},
 							},
 							"user": schema.StringAttribute{
-								Optional:   true,
-								Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+								Optional:    true,
+								Description: "The basic authentication user.",
+								Validators:  []validator.String{stringvalidator.LengthAtLeast(1)},
 							},
 							"password": schema.StringAttribute{
-								Sensitive:  true,
-								Optional:   true,
-								Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+								Sensitive:   true,
+								Optional:    true,
+								Description: "The basic authentication password.",
+								Validators:  []validator.String{stringvalidator.LengthAtLeast(1)},
 							},
 							"token": schema.StringAttribute{
-								Sensitive:  true,
-								Optional:   true,
-								Validators: []validator.String{stringvalidator.LengthAtLeast(1)},
+								Sensitive:   true,
+								Optional:    true,
+								Description: "The bearer token.",
+								Validators:  []validator.String{stringvalidator.LengthAtLeast(1)},
 							},
 						},
 					},


### PR DESCRIPTION
Some of the properties in the alert schema were missing descriptions. Also, add wording (and doc link) for templates and how to use them.

Ref: LOG-20499