### PR TITLE
chore: Prepare for `4.0.0` release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     mezmo = {
       source  = "mezmo/mezmo"
-      version = "~> 3.0.0"
+      version = "~> 4.0.0"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     mezmo = {
       source  = "mezmo/mezmo"
-      version = "~> 3.0.0"
+      version = "~> 4.0.0"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mezmo/terraform-provider-mezmo
+module github.com/mezmo/terraform-provider-mezmo/v4
 
 go 1.21
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,7 +10,7 @@ import (
 	"context"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 type Client interface {

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 type validationError struct {

--- a/internal/provider/access_key_resource.go
+++ b/internal/provider/access_key_resource.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models"
 )
 
 var (

--- a/internal/provider/access_key_resource_test.go
+++ b/internal/provider/access_key_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccessKeyResource(t *testing.T) {

--- a/internal/provider/alert_resource.go
+++ b/internal/provider/alert_resource.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/alerts"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/alerts"
 )
 
 type AlertModel interface {

--- a/internal/provider/alert_resource_definitions.go
+++ b/internal/provider/alert_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/alerts"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/alerts"
 )
 
 func NewThresholdAlertResource() resource.Resource {

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/destinations"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/destinations"
 )
 
 type DestinationModel interface {

--- a/internal/provider/destination_resource_definitions.go
+++ b/internal/provider/destination_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/destinations"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/destinations"
 )
 
 func NewAzureBlobStorageDestinationResource() resource.Resource {

--- a/internal/provider/models/access_key.go
+++ b/internal/provider/models/access_key.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 type AccessKeyResourceModel struct {

--- a/internal/provider/models/alerts/absence.go
+++ b/internal/provider/models/alerts/absence.go
@@ -5,8 +5,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const ALERT_TYPE_ABSENCE = "absence"

--- a/internal/provider/models/alerts/base_model.go
+++ b/internal/provider/models/alerts/base_model.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 type SchemaAttributes map[string]schema.Attribute

--- a/internal/provider/models/alerts/change.go
+++ b/internal/provider/models/alerts/change.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const ALERT_TYPE_CHANGE = "change"

--- a/internal/provider/models/alerts/test/absence_test.go
+++ b/internal/provider/models/alerts/test/absence_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccAbsenceAlert_success(t *testing.T) {

--- a/internal/provider/models/alerts/test/change_test.go
+++ b/internal/provider/models/alerts/test/change_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccChangeAlert_success(t *testing.T) {

--- a/internal/provider/models/alerts/test/provider_test.go
+++ b/internal/provider/models/alerts/test/provider_test.go
@@ -3,7 +3,7 @@ package alerts
 import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/alerts/test/threshold_test.go
+++ b/internal/provider/models/alerts/test/threshold_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccThresholdAlert_success(t *testing.T) {

--- a/internal/provider/models/alerts/threshold.go
+++ b/internal/provider/models/alerts/threshold.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const ALERT_TYPE_THRESHOLD = "threshold"

--- a/internal/provider/models/destinations/azure_blob_storage.go
+++ b/internal/provider/models/destinations/azure_blob_storage.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const AZURE_BLOB_STORAGE_DESTINATION_TYPE_NAME = "azure_blob_storage"

--- a/internal/provider/models/destinations/blackhole.go
+++ b/internal/provider/models/destinations/blackhole.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const BLACKHOLE_DESTINATION_NODE_NAME = "blackhole"

--- a/internal/provider/models/destinations/datadog_logs.go
+++ b/internal/provider/models/destinations/datadog_logs.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const DATADOG_LOGS_DESTINATION_TYPE_NAME = "datadog_logs"

--- a/internal/provider/models/destinations/datadog_metrics.go
+++ b/internal/provider/models/destinations/datadog_metrics.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const DATADOG_METRICS_DESTINATION_TYPE_NAME = "datadog_metrics"

--- a/internal/provider/models/destinations/elasticsearch.go
+++ b/internal/provider/models/destinations/elasticsearch.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const ELASTICSEARCH_DESTINATION_TYPE_NAME = "elasticsearch"

--- a/internal/provider/models/destinations/gcp_cloud_monitoring.go
+++ b/internal/provider/models/destinations/gcp_cloud_monitoring.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const GCP_CLOUD_MONITORING_DESTINATION_TYPE_NAME = "gcp_cloud_monitoring"

--- a/internal/provider/models/destinations/gcp_cloud_operations.go
+++ b/internal/provider/models/destinations/gcp_cloud_operations.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const GCP_CLOUD_OPERATIONS_DESTINATION_TYPE_NAME = "gcp_cloud_operations"

--- a/internal/provider/models/destinations/gcp_cloud_pubsub.go
+++ b/internal/provider/models/destinations/gcp_cloud_pubsub.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const GCP_CLOUD_PUBSUB_DESTINATION_TYPE_NAME = "gcp_cloud_pubsub"

--- a/internal/provider/models/destinations/gcp_cloud_storage.go
+++ b/internal/provider/models/destinations/gcp_cloud_storage.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const GCP_CLOUD_STORAGE_DESTINATION_TYPE_NAME = "gcp_cloud_storage"

--- a/internal/provider/models/destinations/honeycomb_logs.go
+++ b/internal/provider/models/destinations/honeycomb_logs.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const HONEYCOMB_LOGS_DESTINATION_TYPE_NAME = "honeycomb_logs"

--- a/internal/provider/models/destinations/http.go
+++ b/internal/provider/models/destinations/http.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const HTTP_DESTINATION_TYPE_NAME = "http"

--- a/internal/provider/models/destinations/kafka.go
+++ b/internal/provider/models/destinations/kafka.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const KAFKA_DESTINATION_TYPE_NAME = "kafka"

--- a/internal/provider/models/destinations/loki.go
+++ b/internal/provider/models/destinations/loki.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const LOKI_DESTINATION_TYPE_NAME = "loki"

--- a/internal/provider/models/destinations/mezmo.go
+++ b/internal/provider/models/destinations/mezmo.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const MEZMO_DESTINATION_TYPE_NAME = "logs"

--- a/internal/provider/models/destinations/new_relic.go
+++ b/internal/provider/models/destinations/new_relic.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const NEWRELIC_DESTINATION_TYPE_NAME = "new_relic"

--- a/internal/provider/models/destinations/prometheus_remote_write.go
+++ b/internal/provider/models/destinations/prometheus_remote_write.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const PROMETHEUS_REMOTE_WRITE_DESTINATION_TYPE_NAME = "prometheus_remote_write"

--- a/internal/provider/models/destinations/s3.go
+++ b/internal/provider/models/destinations/s3.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const S3_DESTINATION_TYPE_NAME = "s3"

--- a/internal/provider/models/destinations/splunk_hec_logs.go
+++ b/internal/provider/models/destinations/splunk_hec_logs.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const SPLUNK_HEC_LOGS_DESTINATION_TYPE_NAME = "splunk_hec_logs"

--- a/internal/provider/models/destinations/test/azure_blob_storage_test.go
+++ b/internal/provider/models/destinations/test/azure_blob_storage_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccAzureBlobStorageDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/blackhole_test.go
+++ b/internal/provider/models/destinations/test/blackhole_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccBlackholeDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/datadog_logs_test.go
+++ b/internal/provider/models/destinations/test/datadog_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDatadogLogsDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/datadog_metrics_test.go
+++ b/internal/provider/models/destinations/test/datadog_metrics_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDatadogMetricsDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/elasticsearch_test.go
+++ b/internal/provider/models/destinations/test/elasticsearch_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccElasticSearchDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/gcp_cloud_monitoring_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_monitoring_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccGcpCloudMonitoringSinkResource_errors(t *testing.T) {

--- a/internal/provider/models/destinations/test/gcp_cloud_operations_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_operations_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestGcpCloudOperationsSinkResource_errors(t *testing.T) {

--- a/internal/provider/models/destinations/test/gcp_cloud_pubsub_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_pubsub_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccGcpCloudPubSubSinkResource_errors(t *testing.T) {

--- a/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
+++ b/internal/provider/models/destinations/test/gcp_cloud_storage_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccGcpCloudStorageSinkResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/honeycomb_logs_test.go
+++ b/internal/provider/models/destinations/test/honeycomb_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccHoneycombLogsDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/http_test.go
+++ b/internal/provider/models/destinations/test/http_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccHttpDestination(t *testing.T) {

--- a/internal/provider/models/destinations/test/kafka_test.go
+++ b/internal/provider/models/destinations/test/kafka_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccKafkaDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/loki_test.go
+++ b/internal/provider/models/destinations/test/loki_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccLokiDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/mezmo_test.go
+++ b/internal/provider/models/destinations/test/mezmo_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccMezmoDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/new_relic_test.go
+++ b/internal/provider/models/destinations/test/new_relic_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccNewRelicDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/destinations/test/prometheus_remote_write_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccPrometheusDestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/provider_test.go
+++ b/internal/provider/models/destinations/test/provider_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/destinations/test/s3_test.go
+++ b/internal/provider/models/destinations/test/s3_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccS3DestinationResource(t *testing.T) {

--- a/internal/provider/models/destinations/test/splunk_hec_logs_test.go
+++ b/internal/provider/models/destinations/test/splunk_hec_logs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccSplunkHecLogsDestinationResource(t *testing.T) {

--- a/internal/provider/models/modelutils/test/conditional_types_test.go
+++ b/internal/provider/models/modelutils/test/conditional_types_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/provider/models/pipeline.go
+++ b/internal/provider/models/pipeline.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 type PipelineResourceModel struct {

--- a/internal/provider/models/processors/aggregate.go
+++ b/internal/provider/models/processors/aggregate.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const AGGREGATE_PROCESSOR_NODE_NAME = "aggregate"

--- a/internal/provider/models/processors/base_parse_model.go
+++ b/internal/provider/models/processors/base_parse_model.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 var base_options_parser_schema = SchemaAttributes{

--- a/internal/provider/models/processors/compact_fields.go
+++ b/internal/provider/models/processors/compact_fields.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const COMPACT_FIELDS_PROCESSOR_NODE_NAME = "compact-fields"

--- a/internal/provider/models/processors/decrypt_fields.go
+++ b/internal/provider/models/processors/decrypt_fields.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const DECRYPT_FIELDS_PROCESSOR_NODE_NAME = "decrypt-fields"

--- a/internal/provider/models/processors/dedupe.go
+++ b/internal/provider/models/processors/dedupe.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const DEDUPE_PROCESSOR_NODE_NAME = "dedupe"

--- a/internal/provider/models/processors/drop_fields.go
+++ b/internal/provider/models/processors/drop_fields.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const DROP_FIELDS_PROCESSOR_NODE_NAME = "drop-fields"

--- a/internal/provider/models/processors/encrypt_fields.go
+++ b/internal/provider/models/processors/encrypt_fields.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const ENCRYPT_FIELDS_PROCESSOR_NODE_NAME = "encrypt-fields"

--- a/internal/provider/models/processors/event_to_metric.go
+++ b/internal/provider/models/processors/event_to_metric.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const EVENT_TO_METRIC_PROCESSOR_NODE_NAME = "event-to-metric"

--- a/internal/provider/models/processors/filter.go
+++ b/internal/provider/models/processors/filter.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const FILTER_PROCESSOR_NODE_NAME = "filter"

--- a/internal/provider/models/processors/flatten_fields.go
+++ b/internal/provider/models/processors/flatten_fields.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const FLATTEN_FIELDS_PROCESSOR_NODE_NAME = "flatten-fields"

--- a/internal/provider/models/processors/map_fields.go
+++ b/internal/provider/models/processors/map_fields.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const MAP_FIELDS_PROCESSOR_NODE_NAME = "map-fields"

--- a/internal/provider/models/processors/metrics_tag_cardinality_limit.go
+++ b/internal/provider/models/processors/metrics_tag_cardinality_limit.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 type MetricsTagCardinalityLimitProcessorModel struct {

--- a/internal/provider/models/processors/parse.go
+++ b/internal/provider/models/processors/parse.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const PARSE_PROCESSOR_NODE_NAME = "parse"

--- a/internal/provider/models/processors/parse_sequentially.go
+++ b/internal/provider/models/processors/parse_sequentially.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const PARSE_SEQUENTIALLY_PROCESSOR_TYPE_NAME = "parse_sequentially"

--- a/internal/provider/models/processors/reduce.go
+++ b/internal/provider/models/processors/reduce.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const REDUCE_PROCESSOR_NODE_NAME = "reduce"

--- a/internal/provider/models/processors/route.go
+++ b/internal/provider/models/processors/route.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 type RouteProcessorModel struct {

--- a/internal/provider/models/processors/sample.go
+++ b/internal/provider/models/processors/sample.go
@@ -14,8 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const SAMPLE_PROCESSOR_NODE_NAME = "sample"

--- a/internal/provider/models/processors/script_execution.go
+++ b/internal/provider/models/processors/script_execution.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const SCRIPT_EXECUTION_PROCESSOR_NODE_NAME = "js-script"

--- a/internal/provider/models/processors/set_timestamp.go
+++ b/internal/provider/models/processors/set_timestamp.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const SET_TIMESTAMP_PROCESSOR_TYPE_NAME = "set_timestamp"

--- a/internal/provider/models/processors/stringify.go
+++ b/internal/provider/models/processors/stringify.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const STRINGIFY_PROCESSOR_NODE_NAME = "stringify"

--- a/internal/provider/models/processors/test/aggregate_test.go
+++ b/internal/provider/models/processors/test/aggregate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccAggregateProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/compact_fields_test.go
+++ b/internal/provider/models/processors/test/compact_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccCompactFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/decrypt_fields_test.go
+++ b/internal/provider/models/processors/test/decrypt_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDecryptFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/dedupe_test.go
+++ b/internal/provider/models/processors/test/dedupe_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDedupeProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/drop_fields_test.go
+++ b/internal/provider/models/processors/test/drop_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDropFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/encrypt_fields_test.go
+++ b/internal/provider/models/processors/test/encrypt_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccEncryptFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/event_to_metric_test.go
+++ b/internal/provider/models/processors/test/event_to_metric_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccEventToMetricProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/filter_test.go
+++ b/internal/provider/models/processors/test/filter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccFilterProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/flatten_fields_test.go
+++ b/internal/provider/models/processors/test/flatten_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccFlattenFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/map_fields_test.go
+++ b/internal/provider/models/processors/test/map_fields_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccMapFieldsProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/metrics_tag_cardinality_limit_test.go
+++ b/internal/provider/models/processors/test/metrics_tag_cardinality_limit_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccMetricsTagCardinalityLimitProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/parse_sequentially_test.go
+++ b/internal/provider/models/processors/test/parse_sequentially_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccParseSequentiallyProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/parse_test.go
+++ b/internal/provider/models/processors/test/parse_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccParseProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/provider_test.go
+++ b/internal/provider/models/processors/test/provider_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/processors/test/reduce_test.go
+++ b/internal/provider/models/processors/test/reduce_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccReduceProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/route_test.go
+++ b/internal/provider/models/processors/test/route_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccRouteProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/sample_test.go
+++ b/internal/provider/models/processors/test/sample_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccSampleProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/script_execution_test.go
+++ b/internal/provider/models/processors/test/script_execution_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccScriptExecutionProcessor(t *testing.T) {

--- a/internal/provider/models/processors/test/set_timestamp_test.go
+++ b/internal/provider/models/processors/test/set_timestamp_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccSetTimestampProcessor_error(t *testing.T) {

--- a/internal/provider/models/processors/test/stringify_test.go
+++ b/internal/provider/models/processors/test/stringify_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccStringifyProcessorResource(t *testing.T) {

--- a/internal/provider/models/processors/test/unroll_test.go
+++ b/internal/provider/models/processors/test/unroll_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccUnrollProcessor(t *testing.T) {

--- a/internal/provider/models/processors/unroll.go
+++ b/internal/provider/models/processors/unroll.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const UNROLL_PROCESSOR_NODE_NAME = "unroll"

--- a/internal/provider/models/publish_pipeline.go
+++ b/internal/provider/models/publish_pipeline.go
@@ -5,7 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 type PublishPipelineResourceModel struct {

--- a/internal/provider/models/shared_source.go
+++ b/internal/provider/models/shared_source.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 var PUSH_SOURCE_TYPES = []string{

--- a/internal/provider/models/sources/agent.go
+++ b/internal/provider/models/sources/agent.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const AGENT_SOURCE_TYPE_NAME = "agent"

--- a/internal/provider/models/sources/azure_event_hub.go
+++ b/internal/provider/models/sources/azure_event_hub.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const AZURE_EVENT_HUB_SOURCE_TYPE_NAME = "azure_event_hub"

--- a/internal/provider/models/sources/datadog.go
+++ b/internal/provider/models/sources/datadog.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const DATADOG_SOURCE_NODE_NAME = "mezmo-datadog-source"

--- a/internal/provider/models/sources/demo.go
+++ b/internal/provider/models/sources/demo.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const DEMO_SOURCE_NODE_NAME = "demo-logs"

--- a/internal/provider/models/sources/fluent.go
+++ b/internal/provider/models/sources/fluent.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const FLUENT_SOURCE_TYPE_NAME = "fluent"

--- a/internal/provider/models/sources/http.go
+++ b/internal/provider/models/sources/http.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const HTTP_SOURCE_TYPE_NAME = "http"

--- a/internal/provider/models/sources/kafka.go
+++ b/internal/provider/models/sources/kafka.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const KAFKA_SOURCE_TYPE_NAME = "kafka"

--- a/internal/provider/models/sources/kinesis_firehose.go
+++ b/internal/provider/models/sources/kinesis_firehose.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const KINESIS_FIREHOSE_SOURCE_TYPE_NAME = "kinesis_firehose"

--- a/internal/provider/models/sources/log-analysis.go
+++ b/internal/provider/models/sources/log-analysis.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const LOG_ANALYSIS_SOURCE_TYPE_NAME = "log_analysis"

--- a/internal/provider/models/sources/logstash.go
+++ b/internal/provider/models/sources/logstash.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const LOGSTASH_SOURCE_TYPE_NAME = "logstash"

--- a/internal/provider/models/sources/open_telemetry_logs.go
+++ b/internal/provider/models/sources/open_telemetry_logs.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const OPEN_TELEMETRY_LOGS_SOURCE_TYPE_NAME = "open_telemetry_logs"

--- a/internal/provider/models/sources/open_telemetry_metrics.go
+++ b/internal/provider/models/sources/open_telemetry_metrics.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const OPEN_TELEMETRY_METRICS_SOURCE_TYPE_NAME = "open_telemetry_metrics"

--- a/internal/provider/models/sources/open_telemetry_traces.go
+++ b/internal/provider/models/sources/open_telemetry_traces.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const OPEN_TELEMETRY_TRACES_SOURCE_TYPE_NAME = "open_telemetry_traces"

--- a/internal/provider/models/sources/prometheus_remote_write.go
+++ b/internal/provider/models/sources/prometheus_remote_write.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const PROMETHEUS_REMOTE_WRITE_SOURCE_TYPE_NAME = "prometheus_remote_write"

--- a/internal/provider/models/sources/s3.go
+++ b/internal/provider/models/sources/s3.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const S3_SOURCE_TYPE_NAME = "s3"

--- a/internal/provider/models/sources/splunk-hec.go
+++ b/internal/provider/models/sources/splunk-hec.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const SPLUNK_HEC_SOURCE_TYPE_NAME = "splunk_hec"

--- a/internal/provider/models/sources/sqs.go
+++ b/internal/provider/models/sources/sqs.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const SQS_SOURCE_TYPE_NAME = "sqs"

--- a/internal/provider/models/sources/test/agent_test.go
+++ b/internal/provider/models/sources/test/agent_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccAgentSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/azure_event_hub_test.go
+++ b/internal/provider/models/sources/test/azure_event_hub_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccAzureEventHubSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/datadog_test.go
+++ b/internal/provider/models/sources/test/datadog_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDatadogSource(t *testing.T) {

--- a/internal/provider/models/sources/test/demo_test.go
+++ b/internal/provider/models/sources/test/demo_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccDemoSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/fluent_test.go
+++ b/internal/provider/models/sources/test/fluent_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccFluentSource(t *testing.T) {

--- a/internal/provider/models/sources/test/http_test.go
+++ b/internal/provider/models/sources/test/http_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccHttpSource(t *testing.T) {

--- a/internal/provider/models/sources/test/kafka_test.go
+++ b/internal/provider/models/sources/test/kafka_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccKafkaSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/kinesis_firehose_test.go
+++ b/internal/provider/models/sources/test/kinesis_firehose_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccKinesisFirehoseSourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/log_analysis_test.go
+++ b/internal/provider/models/sources/test/log_analysis_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccLogAnalysisSource(t *testing.T) {

--- a/internal/provider/models/sources/test/logstash_test.go
+++ b/internal/provider/models/sources/test/logstash_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccLogStashSource(t *testing.T) {

--- a/internal/provider/models/sources/test/open_telemetry_test.go
+++ b/internal/provider/models/sources/test/open_telemetry_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 type resourceOpenTelemetrySourceConfig struct {

--- a/internal/provider/models/sources/test/prometheus_remote_write_test.go
+++ b/internal/provider/models/sources/test/prometheus_remote_write_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccPrometheusRemoteWriteSource(t *testing.T) {

--- a/internal/provider/models/sources/test/provider_test.go
+++ b/internal/provider/models/sources/test/provider_test.go
@@ -3,7 +3,7 @@ package sources
 import (
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
 )
 
 var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/provider/models/sources/test/s3_test.go
+++ b/internal/provider/models/sources/test/s3_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccS3SourceResource(t *testing.T) {

--- a/internal/provider/models/sources/test/splunk_hec_test.go
+++ b/internal/provider/models/sources/test/splunk_hec_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccSplunkHecSource(t *testing.T) {

--- a/internal/provider/models/sources/test/sqs_test.go
+++ b/internal/provider/models/sources/test/sqs_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccSQSSource(t *testing.T) {

--- a/internal/provider/models/sources/test/webhook_test.go
+++ b/internal/provider/models/sources/test/webhook_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestAccWebhookSource(t *testing.T) {

--- a/internal/provider/models/sources/webhook.go
+++ b/internal/provider/models/sources/webhook.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const WEBHOOK_SOURCE_TYPE_NAME = "webhook"

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models"
 )
 
 var (

--- a/internal/provider/pipeline_resource_test.go
+++ b/internal/provider/pipeline_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestPipelineResource(t *testing.T) {

--- a/internal/provider/processor_resource.go
+++ b/internal/provider/processor_resource.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/processors"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/processors"
 )
 
 type ProcessorModel interface {

--- a/internal/provider/processor_resource_definitions.go
+++ b/internal/provider/processor_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/processors"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/processors"
 )
 
 func NewAggregateProcessorResource() resource.Resource {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 const PROVIDER_TYPE_NAME = "mezmo"

--- a/internal/provider/providertest/utils.go
+++ b/internal/provider/providertest/utils.go
@@ -17,8 +17,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 const authAccountId = "tf_test_01"

--- a/internal/provider/publish_pipeline_resource.go
+++ b/internal/provider/publish_pipeline_resource.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models"
 )
 
 var (

--- a/internal/provider/publish_pipeline_resource_test.go
+++ b/internal/provider/publish_pipeline_resource_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 // Note that this test is not able to test all the possible use cases for this resource.

--- a/internal/provider/shared_source_resource.go
+++ b/internal/provider/shared_source_resource.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/modelutils"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/modelutils"
 )
 
 var (

--- a/internal/provider/shared_source_resource_test.go
+++ b/internal/provider/shared_source_resource_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/providertest"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/providertest"
 )
 
 func TestSharedSourceResource(t *testing.T) {

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/sources"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/sources"
 )
 
 type SourceModel interface {

--- a/internal/provider/source_resource_definitions.go
+++ b/internal/provider/source_resource_definitions.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
-	. "github.com/mezmo/terraform-provider-mezmo/internal/provider/models/sources"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/provider/models/sources"
 )
 
 func NewDemoSourceResource() resource.Resource {

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	. "github.com/mezmo/terraform-provider-mezmo/internal/client"
+	. "github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
 )
 
 // Generic type representing a source / processor / destination model.

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
 )
 
 // Note that Terraform Provider Framework expects a binary called `terraform-provider-{name-of-the-provider}`

--- a/pkg/resources/convertible.go
+++ b/pkg/resources/convertible.go
@@ -6,8 +6,8 @@ import (
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/mezmo/terraform-provider-mezmo/internal/client"
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/client"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
 )
 
 type PipelineApiModel = client.Pipeline

--- a/pkg/resources/convertible_test.go
+++ b/pkg/resources/convertible_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mezmo/terraform-provider-mezmo/internal/provider"
+	"github.com/mezmo/terraform-provider-mezmo/v4/internal/provider"
 )
 
 var (


### PR DESCRIPTION
The next release will be a `major` semver. Start specifying the correct version in the `go.mod` so that `go get` will work with our tags.

Ref: LOG-20552