### PR TITLE
fix(shared-source): missing consumer_id

### DIFF
--- a/docs/resources/shared_source.md
+++ b/docs/resources/shared_source.md
@@ -58,4 +58,5 @@ resource "mezmo_shared_source" "http" {
 
 ### Read-Only
 
+- `consumer_id` (String) Consumer ID of the shared source.
 - `id` (String) The id of the shared source.

--- a/internal/client/types.go
+++ b/internal/client/types.go
@@ -61,6 +61,7 @@ type AccessKey struct {
 
 type SharedSource struct {
 	Id          string `json:"id"`
+	ConsumerId  string `json:"consumer_id"`
 	Title       string `json:"title"`
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type"`

--- a/internal/provider/models/shared_source.go
+++ b/internal/provider/models/shared_source.go
@@ -27,6 +27,7 @@ var PUSH_SOURCE_TYPES = []string{
 
 type SharedSourceResourceModel struct {
 	Id          StringValue `tfsdk:"id"`
+	ConsumerId  StringValue `tfsdk:"consumer_id"`
 	Title       StringValue `tfsdk:"title" user_config:"true"`
 	Description StringValue `tfsdk:"description" user_config:"true"`
 	Type        StringValue `tfsdk:"type" user_config:"true"`
@@ -37,6 +38,10 @@ func SharedSourceResourceSchema() schema.Schema {
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "The id of the shared source.",
+				Computed:    true,
+			},
+			"consumer_id": schema.StringAttribute{
+				Description: "Consumer ID of the shared source.",
 				Computed:    true,
 			},
 			"title": schema.StringAttribute{
@@ -88,6 +93,7 @@ func SharedSourceFromModel(plan *SharedSourceResourceModel) *SharedSource {
 // From an API response to a terraform model
 func SharedSourceToModel(plan *SharedSourceResourceModel, source *SharedSource) {
 	plan.Id = NewStringValue(source.Id)
+	plan.ConsumerId = NewStringValue(source.ConsumerId)
 	plan.Title = NewStringValue(source.Title)
 	plan.Type = NewStringValue(source.Type)
 	if source.Description != "" {

--- a/internal/provider/shared_source_resource_test.go
+++ b/internal/provider/shared_source_resource_test.go
@@ -27,12 +27,13 @@ func TestSharedSourceResource(t *testing.T) {
 					}`) + `
 					resource "mezmo_shared_source" "my_source" {
 						title = "HTTP Shared"
-            type = "http"
-          }
+						type = "http"
+					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput("shared_source_key", regexp.MustCompile(`\w+`)),
 					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "id", IDRegex),
+					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "consumer_id", IDRegex),
 					StateHasExpectedValues("mezmo_shared_source.my_source", map[string]any{
 						"title": "HTTP Shared",
 						"type":  "http",
@@ -44,13 +45,14 @@ func TestSharedSourceResource(t *testing.T) {
 				Config: GetCachedConfig(cacheKey) + `
 					resource "mezmo_shared_source" "my_source" {
 						title = "updated title"
-            description = "updated description"
+						description = "updated description"
 						type = "http"
-          }
+					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput("shared_source_key", regexp.MustCompile(`\w+`)),
 					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "id", IDRegex),
+					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "consumer_id", IDRegex),
 					StateHasExpectedValues("mezmo_shared_source.my_source", map[string]any{
 						"title":       "updated title",
 						"description": "updated description",
@@ -63,11 +65,12 @@ func TestSharedSourceResource(t *testing.T) {
 					resource "mezmo_shared_source" "my_source" {
 						title = "updated title"
 						type = "kinesis-firehose"
-          }
+					}
 				`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchOutput("shared_source_key", regexp.MustCompile(`\w+`)),
 					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "id", IDRegex),
+					resource.TestMatchResourceAttr("mezmo_shared_source.my_source", "consumer_id", IDRegex),
 					resource.TestCheckResourceAttrPair("mezmo_access_key.shared", "source_id", "mezmo_shared_source.my_source", "id"),
 					StateHasExpectedValues("mezmo_shared_source.my_source", map[string]any{
 						"title": "updated title",
@@ -95,9 +98,9 @@ func TestSharedSourceResourceErrors(t *testing.T) {
 				Config: `
 					resource "mezmo_shared_source" "my_source" {
 						title = ""
-            description = ""
-            type = ""
-          }
+						description = ""
+						type = ""
+					}
 				`,
 			},
 		},


### PR DESCRIPTION
Add consumer_id to the shared source model, this ID is what can be used
to derive the endpoint for the shared source.

Ref: LOG-20980 #213 