### PR TITLE
build: update timescale version used in tests

### DIFF
--- a/compose/base.yml
+++ b/compose/base.yml
@@ -3,7 +3,7 @@ version: '2.4'
 services:
 
   timescaledb-service:
-    image: timescale/timescaledb:2.8.1-pg14
+    image: timescale/timescaledb:2.16.1-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
@@ -19,7 +19,7 @@ services:
       retries: 50
 
   timescaledb-metrics:
-    image: timescale/timescaledb:2.8.1-pg14
+    image: timescale/timescaledb:2.16.1-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
Required in order for `make test` to succeed.

Ref: LOG-21139