### PR TITLE
fix(http)!: remove content type without content

### DIFF
--- a/compose/base.yml
+++ b/compose/base.yml
@@ -39,6 +39,14 @@ services:
     environment:
       SERVICES: s3
 
+  dragonfly:
+    image: ghcr.io/dragonflydb/dragonfly:v1.30.1
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+
 # To build pipeline-service locally, set `context` equal to your `pipeline-service` location
 #    build:
 #      context: ../../pipeline-service
@@ -56,6 +64,8 @@ services:
       localstack:
         condition: service_healthy
       account-service:
+        condition: service_healthy
+      dragonfly:
         condition: service_healthy
     command:
       - /bin/bash
@@ -90,6 +100,7 @@ services:
       RESHAPE_MESSAGE_IN_VECTOR: 1
       ACCOUNT_SERVICE_URL: http://account-service:8030
       ENABLE_TAIL_BASED_TRACE_SAMPLING: true
+      KV_STATELESS_URL: redis://dragonfly:6379/0
 
   account-service:
     image: us.gcr.io/logdna-k8s/account-service:1-latest

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -22,3 +22,7 @@ services:
       driver: none
     ports:
       - "8030:8030"
+
+  dragonfly:
+    ports:
+      - '6379:6379'

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -74,7 +74,7 @@ func (c *client) newRequest(method string, url string, body io.Reader) *http.Req
 		}
 	}
 
-	if method != http.MethodGet {
+	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
 	}
 	return req

--- a/internal/provider/providertest/utils.go
+++ b/internal/provider/providertest/utils.go
@@ -343,7 +343,6 @@ func makeDeleteRequest(urlPath string) error {
 	}
 	req.Header.Add("x-account-id", authAccountId)
 	req.Header.Add("x-auth-user-email", authUserEmail)
-	req.Header.Add("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
summary: the pipeline API is being restricted such that a delete call with no content is disallowed. Remove setting such header when applicable. Add new dependency and config for pipeline api.

ref: LOG-23152

BREAKING CHANGE: customers must update their provider
or risk their pipeline changes failing to deploy when
elements are deleted