### PR TITLE
fix(blackhole)!: ack_enabled removed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
+FROM hashicorp/terraform:1.14.1 AS terraform-bin
 FROM golang:1.21-bullseye as test
+
+COPY --from=terraform-bin /bin/terraform /usr/local/bin/terraform
 
 WORKDIR /build
 

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -1,9 +1,7 @@
-version: '2.4'
-
 services:
 
   timescaledb-service:
-    image: timescale/timescaledb:2.16.1-pg14
+    image: timescale/timescaledb-ha:pg14-ts2.16
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
@@ -19,7 +17,7 @@ services:
       retries: 50
 
   timescaledb-metrics:
-    image: timescale/timescaledb:2.16.1-pg14
+    image: timescale/timescaledb-ha:pg14-ts2.16
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -1,5 +1,3 @@
-version: '2.4'
-
 services:
   pipeline-service:
     ports:

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   pipeline-service:
     logging:

--- a/docs/resources/blackhole_destination.md
+++ b/docs/resources/blackhole_destination.md
@@ -40,8 +40,7 @@ resource "mezmo_demo_source" "source1" {
 resource "mezmo_blackhole_destination" "destination1" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "My destination"
-  description = "Trash the data without acking"
-  ack_enabled = false
+  description = "Trash the data"
   inputs      = [mezmo_demo_source.source1.id]
 }
 ```
@@ -55,7 +54,6 @@ resource "mezmo_blackhole_destination" "destination1" {
 
 ### Optional
 
-- `ack_enabled` (Boolean) Acknowledge data from the source when it reaches the destination
 - `description` (String) A user-defined value describing the destination
 - `inputs` (List of String) The ids of the input components
 - `title` (String) A user-defined title for the destination

--- a/docs/resources/parse_sequentially_processor.md
+++ b/docs/resources/parse_sequentially_processor.md
@@ -86,8 +86,7 @@ resource "mezmo_logs_destination" "destination1" {
 resource "mezmo_blackhole_destination" "destination2" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "My destination"
-  description = "Trash the data without acking"
-  ack_enabled = false
+  description = "Trash the data"
   inputs      = [mezmo_parse_sequentially_processor.processor1.parsers.1.output_name]
 }
 

--- a/docs/resources/route_processor.md
+++ b/docs/resources/route_processor.md
@@ -109,8 +109,7 @@ resource "mezmo_logs_destination" "destination1" {
 resource "mezmo_blackhole_destination" "destination2" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "503 logs destination"
-  description = "Trash the data without acking"
-  ack_enabled = false
+  description = "Trash the data"
   inputs      = [mezmo_route_processor.processor1.conditionals.1.output_name]
 }
 
@@ -118,7 +117,6 @@ resource "mezmo_blackhole_destination" "destination3" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Unmatched dest"
   description = "Send unmatched data to blackhole"
-  ack_enabled = false
   inputs      = [mezmo_route_processor.processor1.unmatched]
 }
 ```

--- a/docs/resources/trace_sampling_processor.md
+++ b/docs/resources/trace_sampling_processor.md
@@ -113,14 +113,12 @@ resource "mezmo_trace_sampling_processor" "processor2" {
 resource "mezmo_blackhole_destination" "destination1" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Tail based logs destination"
-  ack_enabled = false
   inputs      = [mezmo_trace_sampling_processor.processor1]
 }
 
 resource "mezmo_blackhole_destination" "destination2" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Head based logs destination"
-  ack_enabled = false
   inputs      = [mezmo_trace_sampling_processor.processor2]
 }
 ```

--- a/examples/resources/mezmo_blackhole_destination/resource.tf
+++ b/examples/resources/mezmo_blackhole_destination/resource.tf
@@ -25,7 +25,6 @@ resource "mezmo_demo_source" "source1" {
 resource "mezmo_blackhole_destination" "destination1" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "My destination"
-  description = "Trash the data without acking"
-  ack_enabled = false
+  description = "Trash the data"
   inputs      = [mezmo_demo_source.source1.id]
 }

--- a/examples/resources/mezmo_parse_sequentially_processor/resource.tf
+++ b/examples/resources/mezmo_parse_sequentially_processor/resource.tf
@@ -71,8 +71,7 @@ resource "mezmo_logs_destination" "destination1" {
 resource "mezmo_blackhole_destination" "destination2" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "My destination"
-  description = "Trash the data without acking"
-  ack_enabled = false
+  description = "Trash the data"
   inputs      = [mezmo_parse_sequentially_processor.processor1.parsers.1.output_name]
 }
 

--- a/examples/resources/mezmo_route_processor/resource.tf
+++ b/examples/resources/mezmo_route_processor/resource.tf
@@ -94,8 +94,7 @@ resource "mezmo_logs_destination" "destination1" {
 resource "mezmo_blackhole_destination" "destination2" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "503 logs destination"
-  description = "Trash the data without acking"
-  ack_enabled = false
+  description = "Trash the data"
   inputs      = [mezmo_route_processor.processor1.conditionals.1.output_name]
 }
 
@@ -103,6 +102,5 @@ resource "mezmo_blackhole_destination" "destination3" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Unmatched dest"
   description = "Send unmatched data to blackhole"
-  ack_enabled = false
   inputs      = [mezmo_route_processor.processor1.unmatched]
 }

--- a/examples/resources/mezmo_trace_sampling_processor/resource.tf
+++ b/examples/resources/mezmo_trace_sampling_processor/resource.tf
@@ -98,13 +98,11 @@ resource "mezmo_trace_sampling_processor" "processor2" {
 resource "mezmo_blackhole_destination" "destination1" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Tail based logs destination"
-  ack_enabled = false
   inputs      = [mezmo_trace_sampling_processor.processor1]
 }
 
 resource "mezmo_blackhole_destination" "destination2" {
   pipeline_id = mezmo_pipeline.pipeline1.id
   title       = "Head based logs destination"
-  ack_enabled = false
   inputs      = [mezmo_trace_sampling_processor.processor2]
 }

--- a/internal/provider/models/destinations/azure_blob_storage.go
+++ b/internal/provider/models/destinations/azure_blob_storage.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,6 +35,12 @@ type AzureBlobStorageDestinationModel struct {
 var AzureBlobStorageResourceSchema = schema.Schema{
 	Description: "Publishes events to Azure Blob Storage",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"encoding": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/base_model.go
+++ b/internal/provider/models/destinations/base_model.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -40,12 +39,6 @@ var baseDestinationSchemaAttributes = SchemaAttributes{
 	"generation_id": schema.Int64Attribute{
 		Computed:    true,
 		Description: "An internal field used for component versioning",
-	},
-	"ack_enabled": schema.BoolAttribute{
-		Optional:    true,
-		Computed:    true,
-		Default:     booldefault.StaticBool(true),
-		Description: "Acknowledge data from the source when it reaches the destination",
 	},
 	"inputs": schema.ListAttribute{
 		ElementType: types.StringType,

--- a/internal/provider/models/destinations/blackhole.go
+++ b/internal/provider/models/destinations/blackhole.go
@@ -19,7 +19,6 @@ type BlackholeDestinationModel struct {
 	Description  String `tfsdk:"description"`
 	Inputs       List   `tfsdk:"inputs"`
 	GenerationId Int64  `tfsdk:"generation_id"`
-	AckEnabled   Bool   `tfsdk:"ack_enabled" user_config:"true"`
 }
 
 var BlackholeDestinationResourceSchema = schema.Schema{
@@ -34,9 +33,7 @@ func BlackholeDestinationFromModel(plan *BlackholeDestinationModel, previousStat
 			Type:        BLACKHOLE_DESTINATION_NODE_NAME,
 			Title:       plan.Title.ValueString(),
 			Description: plan.Description.ValueString(),
-			UserConfig: map[string]any{
-				"ack_enabled": plan.AckEnabled.ValueBool(),
-			},
+			UserConfig:  map[string]any{},
 		},
 	}
 
@@ -72,9 +69,5 @@ func BlackholeDestinationToModel(plan *BlackholeDestinationModel, component *Des
 			inputs = append(inputs, StringValue(v))
 		}
 		plan.Inputs = ListValueMust(StringType, inputs)
-	}
-	if component.UserConfig["ack_enabled"] != nil {
-		value, _ := component.UserConfig["ack_enabled"].(bool)
-		plan.AckEnabled = BoolValue(value)
 	}
 }

--- a/internal/provider/models/destinations/datadog_logs.go
+++ b/internal/provider/models/destinations/datadog_logs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/mezmo/terraform-provider-mezmo/v5/internal/client"
@@ -29,6 +30,12 @@ type DatadogLogsDestinationModel struct {
 var DatadogLogsDestinationResourceSchema = schema.Schema{
 	Description: "Publishes log events to Datadog",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"api_key": schema.StringAttribute{
 			Sensitive:   true,
 			Required:    true,

--- a/internal/provider/models/destinations/datadog_metrics.go
+++ b/internal/provider/models/destinations/datadog_metrics.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/mezmo/terraform-provider-mezmo/v5/internal/client"
@@ -28,6 +29,12 @@ type DatadogMetricsDestinationModel struct {
 var DatadogMetricsDestinationResourceSchema = schema.Schema{
 	Description: "Publishes metric events to Datadog",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"api_key": schema.StringAttribute{
 			Sensitive:   true,
 			Required:    true,

--- a/internal/provider/models/destinations/elasticsearch.go
+++ b/internal/provider/models/destinations/elasticsearch.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -36,6 +37,12 @@ type ElasticSearchDestinationModel struct {
 var ElasticSearchDestinationResourceSchema = schema.Schema{
 	Description: "Represents an ElasticSearch destination.",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"compression": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/gcp_cloud_monitoring.go
+++ b/internal/provider/models/destinations/gcp_cloud_monitoring.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	. "github.com/mezmo/terraform-provider-mezmo/v5/internal/client"
@@ -31,6 +32,12 @@ type GcpCloudMonitoringDestinationModel struct {
 var GcpCloudMonitoringResourceSchema = schema.Schema{
 	Description: "Publish metrics events to GCP Cloud Monitoring",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"credentials_json": schema.StringAttribute{
 			Required:    true,
 			Description: "JSON Credentials",

--- a/internal/provider/models/destinations/gcp_cloud_operations.go
+++ b/internal/provider/models/destinations/gcp_cloud_operations.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	. "github.com/mezmo/terraform-provider-mezmo/v5/internal/client"
@@ -32,6 +33,12 @@ type GcpCloudOperationsDestinationModel struct {
 var GcpCloudOperationsResourceSchema = schema.Schema{
 	Description: "Publish log events to GCP Cloud Operations",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"credentials_json": schema.StringAttribute{
 			Required:    true,
 			Description: "JSON Credentials",

--- a/internal/provider/models/destinations/gcp_cloud_pubsub.go
+++ b/internal/provider/models/destinations/gcp_cloud_pubsub.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -31,6 +32,12 @@ type GcpCloudPubSubDestinationModel struct {
 var GcpCloudPubSubResourceSchema = schema.Schema{
 	Description: "Publish events to GCP Cloud PubSub",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"encoding": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/gcp_cloud_storage.go
+++ b/internal/provider/models/destinations/gcp_cloud_storage.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,6 +34,12 @@ type GcpCloudStorageDestinationModel struct {
 var GcpCloudStorageResourceSchema = schema.Schema{
 	Description: "Publish log events to GCP Cloud Storage",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"encoding": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/honeycomb_logs.go
+++ b/internal/provider/models/destinations/honeycomb_logs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
 	. "github.com/mezmo/terraform-provider-mezmo/v5/internal/client"
@@ -28,6 +29,12 @@ type HoneycombLogsDestinationModel struct {
 var HoneycombLogsResourceSchema = schema.Schema{
 	Description: "Send log data to Honeycomb",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"api_key": schema.StringAttribute{
 			Required:    true,
 			Sensitive:   true,

--- a/internal/provider/models/destinations/http.go
+++ b/internal/provider/models/destinations/http.go
@@ -48,6 +48,12 @@ type HttpDestinationModel struct {
 var HttpDestinationResourceSchema = schema.Schema{
 	Description: "Represents an HTTP destination.",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"uri": schema.StringAttribute{
 			Required: true,
 			Description: "The full URI to make HTTP requests to. This should include the " +

--- a/internal/provider/models/destinations/kafka.go
+++ b/internal/provider/models/destinations/kafka.go
@@ -40,6 +40,12 @@ type KafkaDestinationModel struct {
 var KafkaDestinationResourceSchema = schema.Schema{
 	Description: "Represents a Kafka destination.",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"encoding": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/loki.go
+++ b/internal/provider/models/destinations/loki.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -36,6 +37,12 @@ type LokiDestinationModel struct {
 var LokiDestinationResourceSchema = schema.Schema{
 	Description: "Publish log events to Loki",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"auth": schema.SingleNestedAttribute{
 			Required:    true,
 			Description: "The authentication strategy to use (only basic supported)",

--- a/internal/provider/models/destinations/mezmo.go
+++ b/internal/provider/models/destinations/mezmo.go
@@ -44,6 +44,12 @@ var log_construction_schemes = map[string]string{
 var MezmoDestinationResourceSchema = schema.Schema{
 	Description: "Represents a Mezmo destination.",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"host": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/new_relic.go
+++ b/internal/provider/models/destinations/new_relic.go
@@ -4,6 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -30,6 +31,12 @@ type NewRelicDestinationModel struct {
 var NewRelicDestinationResourceSchema = schema.Schema{
 	Description: "Represents a NewRelic destination.",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"api": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/prometheus_remote_write.go
+++ b/internal/provider/models/destinations/prometheus_remote_write.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -33,6 +34,12 @@ var PrometheusRemoteWriteDestinationResourceSchema = schema.Schema{
 	Description: "Represents Prometheus remote-write destination that publishes metrics to a " +
 		"Prometheus endpoint",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"endpoint": schema.StringAttribute{
 			Required: true,
 			Description: "The full URI to make HTTP requests to. This should include the " +

--- a/internal/provider/models/destinations/s3.go
+++ b/internal/provider/models/destinations/s3.go
@@ -6,6 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	. "github.com/hashicorp/terraform-plugin-framework/types"
@@ -38,6 +39,12 @@ type S3DestinationModel struct {
 var S3DestinationResourceSchema = schema.Schema{
 	Description: "Publishes events as objects in AWS S3",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"auth": schema.SingleNestedAttribute{
 			Required:    true,
 			Description: "Configures AWS authentication",

--- a/internal/provider/models/destinations/splunk_hec_logs.go
+++ b/internal/provider/models/destinations/splunk_hec_logs.go
@@ -55,6 +55,12 @@ var splunkValueTypeAttributes = map[string]schema.Attribute{
 var SplunkHecLogsDestinationResourceSchema = schema.Schema{
 	Description: "Publishes log events to a Splunk HTTP Event Collector",
 	Attributes: ExtendBaseAttributes(map[string]schema.Attribute{
+		"ack_enabled": schema.BoolAttribute{
+			Optional:    true,
+			Computed:    true,
+			Default:     booldefault.StaticBool(true),
+			Description: "Acknowledge data from the source when it reaches the destination",
+		},
 		"compression": schema.StringAttribute{
 			Optional:    true,
 			Computed:    true,

--- a/internal/provider/models/destinations/test/blackhole_test.go
+++ b/internal/provider/models/destinations/test/blackhole_test.go
@@ -38,7 +38,6 @@ func TestAccBlackholeDestinationResource(t *testing.T) {
 						"description":   "my destination description",
 						"generation_id": "0",
 						"title":         "my destination title",
-						"ack_enabled":   "true",
 						"inputs.#":      "0",
 					}),
 				),
@@ -70,7 +69,6 @@ func TestAccBlackholeDestinationResource(t *testing.T) {
 						pipeline_id = mezmo_pipeline.test_parent.id
 						title = "new title"
 						description = "new description"
-						ack_enabled = false
 						inputs = [mezmo_demo_source.my_source.id]
 					}`,
 				Check: resource.ComposeTestCheckFunc(
@@ -78,7 +76,6 @@ func TestAccBlackholeDestinationResource(t *testing.T) {
 						"description":   "new description",
 						"generation_id": "1",
 						"title":         "new title",
-						"ack_enabled":   "false",
 						"inputs.#":      "1",
 					}),
 				),

--- a/pkg/resources/testdata/destinations/blackhole.json
+++ b/pkg/resources/testdata/destinations/blackhole.json
@@ -7,9 +7,7 @@
   "generation_id": 3,
   "type": "blackhole",
   "deploy_type": "saas",
-  "user_config": {
-    "ack_enabled": true
-  },
+  "user_config": {},
   "inputs": [
     "ad6ebb62-63ae-11ee-9b45-26dab184329f",
     "79551faa-6c6a-11ee-be81-6671faf7df66"


### PR DESCRIPTION
summary: the ack feature of the blackhole was recently
removed. Corrected the code and moved the property
to each individual destination from the base model as
its no longer available to all. Swapped docker
timescale image so alleviate a unit test error about
timescaledb_toolkit.control being available. Included
terraform in the docker image build to prevent
testing from needing to manually install it.

BREAKING CHANGE: the ack_enabled property of the blackhole
is no longer available. If you were using this property,
you will need to remove it from your configuration.

ref: LOG-23742